### PR TITLE
add ippool for support k8s multi cluster

### DIFF
--- a/api/ippool/generater.go
+++ b/api/ippool/generater.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022 NetLOX Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ippool
+
+import (
+	"fmt"
+	"net"
+	"sync/atomic"
+)
+
+const (
+	mask24 = uint32(0xFF << 24)
+	mask16 = uint32(0xFF << 16)
+	mask8  = uint32(0xFF << 8)
+	mask0  = uint32(0xFF)
+)
+
+type IPGenerater struct {
+	netCIDR      *net.IPNet
+	uintMaskBits uint32
+	counter      uint32
+}
+
+func InitIPGenerater(cidr string) (*IPGenerater, error) {
+	_, ipn, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CIDR format")
+	}
+
+	maskbit, _ := ipn.Mask.Size()
+	uintMaskBits := uint32(0xFFFFFFFF >> maskbit)
+
+	return &IPGenerater{
+		netCIDR:      ipn,
+		uintMaskBits: uintMaskBits,
+	}, nil
+}
+
+func (i *IPGenerater) NextIP() net.IP {
+	counter := i.counter
+	for !atomic.CompareAndSwapUint32(&i.counter, counter, counter+1) {
+		counter = i.counter
+	}
+
+	counterBit := counter & i.uintMaskBits
+
+	return net.IP{
+		byte(uint32(i.netCIDR.IP[0]) | (counterBit&mask24)>>24),
+		byte(uint32(i.netCIDR.IP[1]) | (counterBit&mask16)>>16),
+		byte(uint32(i.netCIDR.IP[2]) | (counterBit&mask8)>>8),
+		byte(uint32(i.netCIDR.IP[3]) | (counterBit&mask0)>>0),
+	}
+}
+
+func (i *IPGenerater) GetBroadcastIP() net.IP {
+	return net.IP{
+		byte(uint32(i.netCIDR.IP[0]) | (i.uintMaskBits)>>24),
+		byte(uint32(i.netCIDR.IP[1]) | (i.uintMaskBits)>>16),
+		byte(uint32(i.netCIDR.IP[2]) | (i.uintMaskBits)>>8),
+		byte(uint32(i.netCIDR.IP[3]) | (i.uintMaskBits)>>0),
+	}
+}
+
+func (i *IPGenerater) GetNetwork() net.IP {
+	return i.netCIDR.IP
+}
+
+func (i *IPGenerater) CheckIPAddressInSubnet(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	return i.netCIDR.Contains(ip)
+}

--- a/api/ippool/ippool.go
+++ b/api/ippool/ippool.go
@@ -1,0 +1,103 @@
+/*
+Copyright © 2022 Netlox Inc. <backguyn@netlox.io>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ippool
+
+import (
+	"net"
+	"sync"
+)
+
+type IPPool struct {
+	IPv4Generator *IPGenerater
+	IPv4Pool      *IPSet
+	mutex         sync.Mutex
+}
+
+// Initailize IP Pool
+func NewIPPool(netCIDR string) (*IPPool, error) {
+	genIPv4, err := InitIPGenerater(netCIDR)
+	if err != nil {
+		return nil, err
+	}
+
+	poolIPv4 := NewSet()
+	poolIPv4.Add(genIPv4.GetNetwork().String())
+	poolIPv4.Add(genIPv4.GetBroadcastIP().String())
+
+	return &IPPool{
+		IPv4Generator: genIPv4,
+		IPv4Pool:      poolIPv4,
+		mutex:         sync.Mutex{},
+	}, nil
+}
+
+// AssignNewIPv4 generate new IP and add key(IP) in IP Pool.
+// If IP is already in pool, try to generate next IP.
+// Returns nil If all IPs in the subnet are already in the pool.
+func (i *IPPool) AssignNewIPv4() net.IP {
+	startNewIP := i.IPv4Generator.NextIP()
+
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	id := startNewIP.String()
+
+	if ok := i.IPv4Pool.Contains(id); !ok {
+		i.IPv4Pool.Add(id)
+		return startNewIP
+	}
+
+	for {
+		newIP := i.IPv4Generator.NextIP()
+		id := newIP.String()
+		if ok := i.IPv4Pool.Contains(id); !ok {
+			i.IPv4Pool.Add(id)
+			return newIP
+		}
+
+		if startNewIP.Equal(newIP) {
+			return nil
+		}
+	}
+}
+
+// RetrieveIPv4 remove key(IP) in IP Pool
+func (i *IPPool) RetrieveIPv4(retrieveIP string) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	if ok := i.IPv4Pool.Contains(retrieveIP); ok {
+		i.IPv4Pool.Remove(retrieveIP)
+	}
+}
+
+func (i *IPPool) UpdateAllocateddIPv4(allocatedIP string) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	if ok := i.IPv4Pool.Contains(allocatedIP); !ok {
+		i.IPv4Pool.Add(allocatedIP)
+	}
+}
+
+func (i *IPPool) CheckSubnetAndUpdateIPPool(ip string) bool {
+	if i.IPv4Generator.CheckIPAddressInSubnet(ip) {
+		i.UpdateAllocateddIPv4(ip)
+		return true
+	}
+
+	return false
+}

--- a/api/ippool/set.go
+++ b/api/ippool/set.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 NetLOX Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ippool
+
+type IPSet struct {
+	ipaddress map[string]struct{}
+}
+
+var exists = struct{}{}
+
+func NewSet() *IPSet {
+	s := &IPSet{}
+	s.ipaddress = make(map[string]struct{})
+	return s
+}
+
+func (s *IPSet) Add(value string) {
+	s.ipaddress[value] = exists
+}
+
+func (s *IPSet) Remove(value string) {
+	delete(s.ipaddress, value)
+}
+
+func (s *IPSet) Contains(value string) bool {
+	_, c := s.ipaddress[value]
+	return c
+}
+
+func (s *IPSet) GetAll() []string {
+	keys := make([]string, 0, len(s.ipaddress))
+	for k := range s.ipaddress {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (s *IPSet) IsEqual(Pair *IPSet) (isEqual bool, added, deleted IPSet) {
+	isEqual = true
+	for values := range s.ipaddress {
+		c := Pair.Contains(values)
+		if !c {
+			isEqual = false
+			deleted.Add(values)
+		}
+	}
+
+	for values := range Pair.ipaddress {
+		c := s.Contains(values)
+		if !c {
+			isEqual = false
+			added.Add(values)
+		}
+	}
+
+	return isEqual, added, deleted
+}


### PR DESCRIPTION
Currently, it was loxi-ccm's job to allocate an external IP to the k8s loadbalancer service. However, in order for loxi-ccm to support a multi-cluster environment, loxilb must manage the external IP and deliver IP information to loxi-ccm.

So first, I add the ippool that can create an IP in api directory.
In the next step, we will add logic to the API server to allocate a new IP via the API whenever loxi-ccm requests it.