### PR TITLE
PR - Support for clang13 (for Ubuntu 22)

### DIFF
--- a/.github/workflows/basic-sanity-ubuntu-22.yml
+++ b/.github/workflows/basic-sanity-ubuntu-22.yml
@@ -45,4 +45,11 @@ jobs:
              cd cicd/sconnect/
              ./config.sh
              ./validation.sh
+             ./rmconfig.sh
+             cd -
+      - run: |
+             cd cicd/tcplb/
+             ./config.sh
+             ./validation.sh
+             ./rmconfig.sh
              cd -


### PR DESCRIPTION
Currently loxilb is built with clang10 which is not available in Ubuntu12. Clang13 and Clang10 have subtle differences which is addressed by this PR. Also, the CICD for Ubuntu22 is enhanced. 