### PR TITLE
Add CICD on the EKS

### DIFF
--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,4 +1,4 @@
-name: 'LoxiLB with EKS test'
+name: 'EKS'
 
 on:
  schedule:
@@ -9,7 +9,7 @@ on:
       testName:
         description: 'Test Run-Name'     
         required: true
-        default: 'LoxiLB with EKS test'
+        default: 'EKS'
   
 permissions:
   contents: read

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -103,7 +103,11 @@ jobs:
         kubectl apply -f udp-svc.yaml
         sleep 10
         kubectl apply -f sctp-svc.yaml
-        sleep 10
+        sleep 20
+        echo "**** svc info ****"
+        kubectl get svc
+        echo "**** pods info ****"
+        kubectl get pods -A
            
     - name: Host Commands
       uses: appleboy/ssh-action@v0.1.6
@@ -112,13 +116,12 @@ jobs:
         username: ${{ env.HOST_USER }}
         key: ${{ secrets.AWS_SSH_KEY }}
         port: 22
-        script_stop: true
         script: |
           curl http://${{ env.LOXILB_PUBLIC_IP }}:8080
           sleep 10
           ./udp_client ${{ env.LOXILB_PUBLIC_IP }} 50003
           sleep 10
-          ./sctp_client ${{ env.HOST_PRIVATE_IP }} 0 ${{ env.LOXILB_PUBLIC_IP }} 55004
+          for i in $(seq 1 10); do    ./sctp_client ${{ env.HOST_PRIVATE_IP }} 0 ${{ env.LOXILB_PUBLIC_IP }} 55004;    sleep 1; done
     
     - name: delete k8s configure
       run: |

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -116,9 +116,9 @@ jobs:
         script: |
           curl http://${{ env.LOXILB_PUBLIC_IP }}:8080
           sleep 10
-          ../common/udp_client ${{ env.LOXILB_PUBLIC_IP }} 50003
+          ./udp_client ${{ env.LOXILB_PUBLIC_IP }} 50003
           sleep 10
-          ../common/sctp_client ${{ env.HOST_PRIVATE_IP }} 0 ${{ env.LOXILB_PUBLIC_IP }} 55004
+          ./sctp_client ${{ env.HOST_PRIVATE_IP }} 0 ${{ env.LOXILB_PUBLIC_IP }} 55004
     
     - name: delete k8s configure
       run: |

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,0 +1,133 @@
+name: 'LoxiLB with EKS test'
+
+on:
+ schedule:
+ # Runs "At 11:00 UTC every day-of-week"
+ - cron: '0 11 * * *'
+ workflow_dispatch:
+    inputs:
+      testName:
+        description: 'Test Run-Name'     
+        required: true
+        default: 'LoxiLB with EKS test'
+  
+permissions:
+  contents: read
+env: 
+  AWS_REGION: ap-northeast-3
+
+jobs:
+  terraform:
+    name: 'Terraform with eks'
+    runs-on: ubuntu-latest
+    environment: production
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./cicd/eks      
+      
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # AWS check 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+  
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      run: terraform init
+      
+    # Generates an execution plan for Terraform
+    - name: Terraform Plan
+      run: terraform plan -input=false
+      
+    - name: Terraform Apply
+      run: terraform apply -auto-approve -input=false
+      
+    - name: Install and kubectl
+      run: |
+        VERSION=$(curl --silent https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+        curl https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl \
+          --progress-bar \
+          --location \
+          --remote-name
+        chmod +x kubectl
+        sudo mv kubectl /usr/local/bin/
+
+    - name: Get envs
+      run: |
+        echo "LOXILB_PUBLIC_IP=$(terraform output -raw loxilb_public_ip)" >> $GITHUB_ENV
+        echo "LOXILB_PRIVATE_IP=$(terraform output -raw loxilb_private_ip)" >> $GITHUB_ENV
+        echo "HOST_PUBLIC_IP=$(terraform output -raw host_public_ip)" >> $GITHUB_ENV
+        echo "HOST_PRIVATE_IP=$(terraform output -raw host_private_ip)" >> $GITHUB_ENV
+        echo "LOXILB_USER=ubuntu" >> $GITHUB_ENV
+        echo "HOST_USER=ubuntu" >> $GITHUB_ENV
+
+    - name: Loxilb update
+      uses: appleboy/ssh-action@v0.1.6
+      with:          
+        host: ${{ env.LOXILB_PUBLIC_IP }}
+        username: ${{ env.LOXILB_USER }}
+        key: ${{ secrets.AWS_SSH_KEY }}
+        port: 22
+        script_stop: true
+        script: |
+            sudo docker image pull ghcr.io/loxilb-io/loxilb:latest
+            sudo docker stop loxilb
+            sudo docker rm loxilb
+            sudo docker run -u root --cap-add SYS_ADMIN --net host  --restart unless-stopped --privileged -dit -v /dev/log:/dev/log --name loxilb ghcr.io/loxilb-io/loxilb:latest
+            sleep 20
+            sudo docker exec loxilb /root/loxilb-io/loxilb/loxilb -v
+      
+    - name: get kubeconfig
+      run: aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)
+      
+    - name: kube-loxilb apply
+      run: |
+        export LOXILB_PRIVATE_IP=${{ env.LOXILB_PRIVATE_IP }}
+        envsubst < kube-loxilb.yaml  | kubectl apply -f -
+        sleep 60
+    
+    - name: make Service with Pod
+      run: |
+        kubectl apply -f nginx-svc.yaml
+        sleep 10
+        kubectl apply -f udp-svc.yaml
+        sleep 10
+        kubectl apply -f sctp-svc.yaml
+        sleep 10
+           
+    - name: Host Commands
+      uses: appleboy/ssh-action@v0.1.6
+      with:
+        host: ${{ env.HOST_PUBLIC_IP }}
+        username: ${{ env.HOST_USER }}
+        key: ${{ secrets.AWS_SSH_KEY }}
+        port: 22
+        script_stop: true
+        script: |
+          curl http://${{ env.LOXILB_PUBLIC_IP }}:8080
+          sleep 10
+          ../common/udp_client ${{ env.LOXILB_PUBLIC_IP }} 50003
+          sleep 10
+          ../common/sctp_client ${{ env.HOST_PRIVATE_IP }} 0 ${{ env.LOXILB_PUBLIC_IP }} 55004
+    
+    - name: delete k8s configure
+      run: |
+        kubectl delete -f nginx-svc.yaml
+        kubectl delete -f udp-svc.yaml
+        kubectl delete -f sctp-svc.yaml
+        kubectl delete -f kube-loxilb.yaml
+        
+    - name : delete testbed
+      if: ${{ always() }}
+      run: |
+        terraform destroy  -auto-approve -input=false

--- a/cicd/eks/kube-loxilb.yaml
+++ b/cicd/eks/kube-loxilb.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-loxilb
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-loxilb
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - watch
+      - list
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - watch
+      - list
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - services
+      - services/status
+    verbs:
+      - get
+      - watch
+      - list
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-loxilb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-loxilb
+subjects:
+  - kind: ServiceAccount
+    name: kube-loxilb
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-loxilb
+  namespace: kube-system
+  labels:
+    app: loxilb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loxilb
+  template:
+    metadata:
+      labels:
+        app: loxilb
+    spec:
+      hostNetwork: true
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      priorityClassName: system-node-critical
+      serviceAccountName: kube-loxilb
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: kube-loxilb
+        image: ghcr.io/loxilb-io/kube-loxilb:latest
+        imagePullPolicy: Always
+        command:
+        - /bin/kube-loxilb
+        args:
+        - --loxiURL=http://$LOXILB_PRIVATE_IP:11111
+        - --externalCIDR=$LOXILB_PRIVATE_IP/32
+        #- --externalSecondaryCIDRs=124.124.124.1/24,125.125.125.1/24
+        #- --monitor
+        #- --setBGP
+        - --setLBMode=2
+        #- --config=/opt/loxilb/agent/kube-loxilb.conf
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]

--- a/cicd/eks/main.tf
+++ b/cicd/eks/main.tf
@@ -1,0 +1,197 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  cluster_name = "loxilb-eks-${random_string.suffix.result}"
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+  name = "loxilb-cicd-vpc"  
+  cidr = "10.0.0.0/16"
+  azs  = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = 1
+  }
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.15.3"
+
+  cluster_name    = local.cluster_name
+  cluster_version = "1.27"
+
+  vpc_id                         = module.vpc.vpc_id
+  subnet_ids                     = module.vpc.private_subnets
+  cluster_endpoint_public_access = true
+
+  eks_managed_node_group_defaults = {
+    ami_type = "AL2_x86_64"
+  }
+  
+  eks_managed_node_groups = {
+    node = {
+      name = "node-group"
+      instance_types = ["t3.small"]
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+    }
+  }
+}
+
+module "ec2_instance" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  name = "loxilb_node"
+  
+  ami = "ami-0c016e131d2da56e8"
+  instance_type          = "t3.small"
+  key_name               = "aws-osaka"
+  monitoring             = true
+  
+  vpc_security_group_ids = [ module.security-group.security_group_id]
+  subnet_id              = module.vpc.public_subnets[0]
+  associate_public_ip_address = "true"
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+}    
+
+module "ec2_instance2" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  name = "host_node"
+
+  ami = "ami-0d126351255167386"
+  instance_type          = "t3.small"
+  key_name               = "aws-osaka"
+  monitoring             = true
+
+  vpc_security_group_ids = [ module.security-group.security_group_id]
+  subnet_id              = module.vpc.public_subnets[0]
+  associate_public_ip_address = "true"
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+}
+
+
+# https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons/ 
+data "aws_iam_policy" "ebs_csi_policy" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+module "irsa-ebs-csi" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.7.0"
+
+  create_role                   = true
+  role_name                     = "AmazonEKSTFEBSCSIRole-${module.eks.cluster_name}"
+  provider_url                  = module.eks.oidc_provider
+  role_policy_arns              = [data.aws_iam_policy.ebs_csi_policy.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+}
+
+module "security-group" {
+  source  = "terraform-aws-modules/security-group/aws" 
+  version = "5.1.0"                                    
+  name        = "LoxiLB-node-sg" 
+  description = "LoxiLB node security group"
+  vpc_id      = module.vpc.vpc_id
+  use_name_prefix = "false" 
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      description = "ssh"
+      cidr_blocks = "0.0.0.0/0"
+    },{
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      description = "http"
+      cidr_blocks = "0.0.0.0/0"
+    },{
+      from_port   = 8080
+      to_port     = 8080
+      protocol    = "tcp"
+      description = "http_tmp"
+      cidr_blocks = "0.0.0.0/0"
+    },{
+      from_port   = 11111
+      to_port     = 11111
+      protocol    = "tcp"
+      description = "loxilb"
+      cidr_blocks = "0.0.0.0/0"
+    },{
+      from_port   = 0
+      to_port     = 65535
+      protocol    = 132
+      description = "sctp protocol"
+      cidr_blocks = "0.0.0.0/0"
+    },{
+      from_port   = 50003
+      to_port     = 50003
+      protocol    = "udp"
+      description = "udp"
+      cidr_blocks = "0.0.0.0/0"
+    },
+  ]
+  ingress_with_source_security_group_id = [
+    {
+      from_port   = 0
+      to_port     = 65535
+      protocol    = "all"
+      description = "all"
+      source_security_group_id = module.eks.node_security_group_id
+    },
+  ]
+  egress_with_cidr_blocks = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      description = "all"
+      cidr_blocks = "0.0.0.0/0"
+    }
+]
+}
+
+resource "aws_security_group_rule" "ingress_with_cluter_to_loxilb" {
+       description              = "all"
+       from_port                = 1
+       protocol                 = "all"
+       security_group_id        = module.eks.node_security_group_id
+       source_security_group_id = module.security-group.security_group_id
+       to_port                  = 65535
+       type                     = "ingress"
+}
+

--- a/cicd/eks/nginx-svc.yaml
+++ b/cicd/eks/nginx-svc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-lb1
+  annotations:
+   loxilb.io/liveness : "yes"
+spec:
+  externalTrafficPolicy: Local
+  loadBalancerClass: loxilb.io/loxilb
+  selector:
+    what: nginx-test
+  ports:
+    - port: 8080
+      targetPort: 80 
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-test
+  labels:
+    what: nginx-test
+spec:
+  containers:
+    - name: nginx-test
+      image: nginx:stable
+      ports:
+        - containerPort: 80

--- a/cicd/eks/outputs.tf
+++ b/cicd/eks/outputs.tf
@@ -1,0 +1,41 @@
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ids attached to the cluster control plane"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "cluster_name" {
+  description = "Kubernetes Cluster Name"
+  value       = module.eks.cluster_name
+}
+
+output "loxilb_private_ip" {
+  description = "loxilb private ip address"
+  value       = module.ec2_instance.private_ip
+}
+
+output "loxilb_public_ip" {
+  description = "loxilb public ip address"
+  value       = module.ec2_instance.public_ip
+}
+
+output "host_private_ip" {
+  description = "host private ip address"
+  value       = module.ec2_instance2.private_ip
+}
+
+output "host_public_ip" {
+  description = "host public ip address"
+  value       = module.ec2_instance2.public_ip
+}
+
+

--- a/cicd/eks/sctp-svc.yaml
+++ b/cicd/eks/sctp-svc.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sctp-lb1
+  annotations:
+   loxilb.io/liveness: "yes"
+   loxilb.io/lbmode: "fullnat"
+spec:
+  loadBalancerClass: loxilb.io/loxilb
+  externalTrafficPolicy: Local
+  selector:
+    what: sctp-test
+  ports:
+    - port: 55004
+      protocol: SCTP
+      targetPort: 9999
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sctp-test
+  labels:
+    what: sctp-test
+spec:
+  containers:
+    - name: sctp-test
+      image: alpine/socat
+      command: [ "sh", "-c"]
+      args:
+      - while true; do
+          socat -v -T2 sctp-l:9999,reuseaddr,fork system:"echo 'server1'; cat";
+          sleep 20;
+        done;
+      ports:
+        - containerPort: 9999
+      env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP

--- a/cicd/eks/terraform.tf
+++ b/cicd/eks/terraform.tf
@@ -1,0 +1,27 @@
+terraform {
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.6.1"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0.4"
+    }
+
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.2.0"
+    }
+  }
+
+  required_version = "~> 1.3"
+}
+

--- a/cicd/eks/udp-svc.yaml
+++ b/cicd/eks/udp-svc.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-lb1
+  annotations:
+   loxilb.io/liveness: "yes"
+   loxilb.io/lbmode: "fullnat"
+spec:
+  loadBalancerClass: loxilb.io/loxilb
+  externalTrafficPolicy: Local
+  selector:
+    what: udp-test
+  ports:
+    - port: 50003
+      protocol: UDP
+      targetPort: 33333
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: udp-test
+  labels:
+    what: udp-test
+spec:
+  containers:
+    - name: udp-test
+      image: loxilbio/udp-echo
+      ports:
+        - containerPort: 33333

--- a/cicd/eks/variables.tf
+++ b/cicd/eks/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-3"
+}


### PR DESCRIPTION
This PR contain 2 scripts.

> 1. Terraform script 
> 2. Github action script

- Terraform script will deploy Host, LoxiLB instances and 2 node's EKS.
- Host instance image needs to contain "udp_client", "sctp_client" binary in cicd/common directory.
- LoxiLB instance image needs to contain "docker".
- Github action need secrets of AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SSH_KEY.