### PR TITLE
fix base error's value

### DIFF
--- a/loxinet/dpbroker.go
+++ b/loxinet/dpbroker.go
@@ -23,8 +23,9 @@ import (
 	"sync"
 	"time"
 
-	cmn "github.com/loxilb-io/loxilb/common"
 	tk "github.com/loxilb-io/loxilib"
+
+	cmn "github.com/loxilb-io/loxilb/common"
 )
 
 // man names constants
@@ -43,7 +44,7 @@ const (
 
 // error codes
 const (
-	DpErrBase = iota - L3ErrBase - 1000
+	DpErrBase = iota - 103000
 	DpWqUnkErr
 )
 
@@ -311,7 +312,7 @@ type DpCtInfo struct {
 	ServProto  string `json:"servproto"`
 	L4ServPort uint16 `json:"l4servproto"`
 	BlockNum   uint16 `json:"blocknum"`
-	RuleID	   uint32 `json:"ruleid"`
+	RuleID     uint32 `json:"ruleid"`
 }
 
 const (
@@ -817,7 +818,7 @@ func (dp *DpH) DpMapGetCt4() []cmn.CtInfo {
 	switch r := ret.(type) {
 	case map[string]*DpCtInfo:
 		for _, dCti := range r {
-			
+
 			mh.mtx.Lock()
 			rule := mh.zr.Rules.GetNatLbRuleByID(dCti.RuleID)
 			mh.mtx.Unlock()

--- a/loxinet/layer3.go
+++ b/loxinet/layer3.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"net"
 
-	cmn "github.com/loxilb-io/loxilb/common"
 	tk "github.com/loxilb-io/loxilib"
+
+	cmn "github.com/loxilb-io/loxilb/common"
 )
 
 // constants
 const (
-	L3ErrBase = iota - RtErrBase - 1000
+	L3ErrBase = iota - 8000
 	L3AddrErr
 	L3ObjErr
 )

--- a/loxinet/rules.go
+++ b/loxinet/rules.go
@@ -40,7 +40,7 @@ import (
 
 // error codes
 const (
-	RuleErrBase = iota - ZoneBaseErr - 1000
+	RuleErrBase = iota - 7000
 	RuleUnknownServiceErr
 	RuleUnknownEpErr
 	RuleExistsErr
@@ -272,7 +272,7 @@ type ruleEnt struct {
 	act      ruleAct
 	secIP    []ruleNatSIP
 	stat     ruleStat
-	name	 string
+	name     string
 }
 
 type ruleTable struct {

--- a/loxinet/session.go
+++ b/loxinet/session.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"net"
 
-	cmn "github.com/loxilb-io/loxilb/common"
 	tk "github.com/loxilb-io/loxilib"
+
+	cmn "github.com/loxilb-io/loxilb/common"
 )
 
 // error codes for session api
 const (
-	SessErrBase = iota - 90000
+	SessErrBase = iota - 102000
 	SessModErr
 	SessNoExistErr
 	SessExistsErr

--- a/loxinet/zones.go
+++ b/loxinet/zones.go
@@ -28,7 +28,7 @@ import (
 
 // error codes for zone
 const (
-	ZoneBaseErr = iota - RtErrBase - 1000
+	ZoneBaseErr = iota - 6000
 	ZoneExistsErr
 	ZoneNotExistErr
 	ZoneNumberErr


### PR DESCRIPTION
PortBaseErr = 	iota - 1000
VlanBaseErr = 	iota - 2000
L2ErrBase = 	        iota - 3000
NeighErrBase = 	iota - 4000
RtErrBase = 	         iota - 5000
ZoneBaseErr = 	iota - RtErrBase - 1000 	   = 4000	   fixed to ZoneBaseErr = iota - 6000 
RuleErrBase = 	iota - ZoneBaseErr - 1000 = -5000  fixed to RuleErrBase = iota - 7000
L3ErrBase = 	        iota - RtErrBase - 1000      = 4000    fixed to L3ErrBase = iota - 8000
CIErrBase = 	        iota - 90000
PolErrBase = 	        iota - 100000
MirrErrBase = 	        iota - 101000
SessErrBase = 	iota - 90000 					   fixed to SessErrBase = iota - 102000
DpErrBase = 	       iota - L3ErrBase - 1000  	    = -5000  fixed to DpErrBase = iota - 103000