### PR TITLE
cicd/tcpsctpperf: set -eo pipefail to ease debugging

### DIFF
--- a/cicd/tcpsctpperf/config.sh
+++ b/cicd/tcpsctpperf/config.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 source ../common.sh
 

--- a/cicd/tcpsctpperf/validation.sh
+++ b/cicd/tcpsctpperf/validation.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 source ../common.sh
 if [ -z "$1" ]; then
     threads=50


### PR DESCRIPTION
Not adding to rmconfig.sh, because it can also be used for cleanup before running config.sh and then it is expected to fail.

set -u would also be nice, but it requires more modifications to the scripts.