### PR TITLE
cicd/tcpsctpperf: Hotfix to restore old bahavaiour without additional args

### DIFF
--- a/cicd/tcpsctpperf/config.sh
+++ b/cicd/tcpsctpperf/config.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
+export OSE_LOXILB_SERVERS=${OSE_LOXILB_SERVERS:-1}
+
 source ../common.sh
 
 echo "#########################################"

--- a/cicd/tcpsctpperf/rmconfig.sh
+++ b/cicd/tcpsctpperf/rmconfig.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export OSE_LOXILB_SERVERS=${OSE_LOXILB_SERVERS:-1}
+
 source ../common.sh
 
 disconnect_docker_hosts l3h1 llb1

--- a/cicd/tcpsctpperf/validation.sh
+++ b/cicd/tcpsctpperf/validation.sh
@@ -44,13 +44,13 @@ $dexec llb1 bash -c "nohup /root/loxilb-io/loxilb/loxilb --rss-enable >> /dev/nu
 sleep 40
 for ((i=1,port=12865;i<=100;i++,port++))
 do
-  $dexec llb1 loxicmd create lb 20.20.20.1 --tcp=$port:$port  --endpoints=31.31.31.1:1 >> /dev/null
+  $dexec llb1 loxicmd create lb 20.20.20.1 --tcp=$port:$port  --endpoints=31.31.1.1:1 >> /dev/null
 done
 
-$dexec llb1 loxicmd create lb 20.20.20.1 --tcp=13866:13866  --endpoints=31.31.31.1:1 >> /dev/null
+$dexec llb1 loxicmd create lb 20.20.20.1 --tcp=13866:13866  --endpoints=31.31.1.1:1 >> /dev/null
 for ((i=1,port=13866;i<=100;i++,port++))
 do
-  $dexec llb1 loxicmd create lb 20.20.20.1 --sctp=$port:$port  --endpoints=31.31.31.1:1 >> /dev/null
+  $dexec llb1 loxicmd create lb 20.20.20.1 --sctp=$port:$port  --endpoints=31.31.1.1:1 >> /dev/null
 done
 
 sleep 20


### PR DESCRIPTION
Not tested yet, let's what the CI says regarding this.