### PR TITLE
#87 Do not use of docker pid and cgroup option for all cases

### DIFF
--- a/cicd/common.sh
+++ b/cicd/common.sh
@@ -16,6 +16,7 @@ hostdocker="ghcr.io/loxilb-io/nettest:latest"
 cluster_opts=""
 extra_opts=""
 ka_opts=""
+docker_extra_opts=""
 #var=$(lsb_release -r | cut -f2)
 #if [[ $var == *"22.04"* ]];then
 #  lxdocker="ghcr.io/loxilb-io/loxilb:latestu22"
@@ -76,7 +77,7 @@ spawn_docker_host() {
       fi
       shift 2
       ;;
-    -d | --ka-config )
+    -n | --ka-config )
       kpath="$2"
       if [[ -z ${ka+x} ]]; then
         ka="in"
@@ -85,6 +86,10 @@ spawn_docker_host() {
       ;;
     -e | --extra-args)
       extra_opts="$2"
+      shift 2
+      ;;
+    -x | --docker-args)
+      docker_extra_opts="$2"
       shift 2
       ;;
     -*|--*)
@@ -109,11 +114,11 @@ spawn_docker_host() {
     fi
     if [[ ! -z ${ka+x} ]]; then
       sudo mkdir -p /etc/shared/$dname/
-      docker run -u root --cap-add SYS_ADMIN   --restart unless-stopped --privileged -dt --pid=host --cgroupns=host --entrypoint /bin/bash $bgp_conf -v /dev/log:/dev/log -v /etc/shared/$dname:/etc/shared $loxilb_config --name $dname $lxdocker
+      docker run -u root --cap-add SYS_ADMIN   --restart unless-stopped --privileged -dt $docker_extra_opts --entrypoint /bin/bash $bgp_conf -v /dev/log:/dev/log -v /etc/shared/$dname:/etc/shared $loxilb_config --name $dname $lxdocker
       get_llb_peerIP $dname
       docker exec -dt $dname /root/loxilb-io/loxilb/loxilb $bgp_opts $cluster_opts $ka_opts $extra_opts
     else
-      docker run -u root --cap-add SYS_ADMIN   --restart unless-stopped --privileged -dt --pid=host --cgroupns=host --entrypoint /bin/bash $bgp_conf -v /dev/log:/dev/log $loxilb_config --name $dname $lxdocker $bgp_opts
+      docker run -u root --cap-add SYS_ADMIN   --restart unless-stopped --privileged -dt $docker_extra_opts --entrypoint /bin/bash $bgp_conf -v /dev/log:/dev/log $loxilb_config --name $dname $lxdocker $bgp_opts
       docker exec -dt $dname /root/loxilb-io/loxilb/loxilb $bgp_opts $cluster_opts $extra_opts
     fi
   elif [[ "$dtype" == "host" ]]; then

--- a/cicd/tcplb-local/config.sh
+++ b/cicd/tcplb-local/config.sh
@@ -6,7 +6,7 @@ echo "#########################################"
 echo "Spawning all hosts"
 echo "#########################################"
 
-spawn_docker_host --dock-type loxilb --dock-name llb1 --extra-args "--localsockpolicy"
+spawn_docker_host --dock-type loxilb --dock-name llb1 --docker-args "--pid=host --cgroupns=host" --extra-args "--localsockpolicy"
 spawn_docker_host --dock-type host --dock-name l3h1
 spawn_docker_host --dock-type host --dock-name l3ep1
 spawn_docker_host --dock-type host --dock-name l3ep2


### PR DESCRIPTION
Using ```--pid=host --cgroupns=host``` for docker cicd tests makes loxilb pid and cgroup appear in the host system. This creates a lot of confusion. This commit only uses pid and cgroups options for specific tests that need those options.