### PR TITLE
PR: Fixed incorrect Knowledge-Base links in the README

### DIFF
--- a/README-KOR.md
+++ b/README-KOR.md
@@ -108,7 +108,7 @@ loxilb는 기본적으로 L4 로드 밸런서/서비스 프록시로 작동합�
 - [How-To : ingress-nginx와 함께 loxilb 배포](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/loxilb-nginx-ingress.md)
 
 ## 배경 지식
-- [eBPF란 무엇인가](ebpf.md)
+- [eBPF란 무엇인가](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/ebpf.md)
 - [k8s 서비스 - 로드 밸런서란 무엇인가](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/lb.md)
 - [간단한 아키텍처](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/arch.md)
 - [코드 조직](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/code.md)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Telco-cloud requires load-balancing and communication across various interfaces/
 - [How-To : Run loxilb in-cluster with secondary networks](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/loxilb-incluster-multus.md)
 
 ## Knowledge-Base   
-- [What is eBPF](ebpf.md)
+- [What is eBPF](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/ebpf.md)
 - [What is k8s service - load-balancer](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/lb.md)
 - [Architecture in brief](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/arch.md)
 - [Code organization](https://github.com/loxilb-io/loxilbdocs/blob/main/docs/code.md)


### PR DESCRIPTION
I noticed that the link to “What is eBPF” in the Knowledge-Base section is currently invalid
I looked at the other link and realized that the documentation had changed to the https://github.com/loxilb-io/loxilbdocs repository, so I changed it to that link.