### PR TITLE
IfaSelect return at least ip of same protocol of dest addr

### DIFF
--- a/pkg/loxinet/layer3.go
+++ b/pkg/loxinet/layer3.go
@@ -281,6 +281,12 @@ func (l3 *L3H) IfaSelect(Obj string, addr net.IP, findAny bool) (int, net.IP, st
 					continue
 				}
 				if len(ifa.Ifas) > 0 {
+					for _, ifaEnt := range ifa.Ifas {
+						if (tk.IsNetIPv4(addr.String()) && tk.IsNetIPv4(ifaEnt.IfaNet.IP.String())) ||
+							(tk.IsNetIPv6(addr.String()) && tk.IsNetIPv6(ifaEnt.IfaNet.IP.String())) {
+							return 0, ifaEnt.IfaAddr, Obj
+						}
+					}
 					return 0, ifa.Ifas[0].IfaAddr, Obj
 				}
 			}
@@ -309,6 +315,12 @@ func (l3 *L3H) IfaSelect(Obj string, addr net.IP, findAny bool) (int, net.IP, st
 
 	// Select first IP
 	if len(ifa.Ifas) > 0 {
+		for _, ifaEnt := range ifa.Ifas {
+			if (tk.IsNetIPv4(addr.String()) && tk.IsNetIPv4(ifaEnt.IfaNet.IP.String())) ||
+				(tk.IsNetIPv6(addr.String()) && tk.IsNetIPv6(ifaEnt.IfaNet.IP.String())) {
+				return 0, ifaEnt.IfaAddr, Obj
+			}
+		}
 		return 0, ifa.Ifas[0].IfaAddr, Obj
 	}
 


### PR DESCRIPTION
issue raised here https://github.com/loxilb-io/loxilb/issues/925

the source ip used for check the endpoints is retrieved with using IfaSelect
IfaSelect currently return as a fallback solution the first ip of the interface
it should a least return an ip of the same protocol of the addr targeted so the endpoints can be checked

