### PR TITLE
PR - External API control for manipulating end-point health

### DIFF
--- a/api/restapi/configure_loxilb_rest_api.go
+++ b/api/restapi/configure_loxilb_rest_api.go
@@ -159,6 +159,7 @@ func configureAPI(api *operations.LoxilbRestAPIAPI) http.Handler {
 	api.GetConfigEndpointAllHandler = operations.GetConfigEndpointAllHandlerFunc(handler.ConfigGetEndPoint)
 	api.PostConfigEndpointHandler = operations.PostConfigEndpointHandlerFunc(handler.ConfigPostEndPoint)
 	api.DeleteConfigEndpointEpipaddressIPAddressHandler = operations.DeleteConfigEndpointEpipaddressIPAddressHandlerFunc(handler.ConfigDeleteEndPoint)
+	api.PostConfigEndpointhoststateHandler = operations.PostConfigEndpointhoststateHandlerFunc(handler.ConfigPostEndPointHostState)
 
 	// Params
 	api.PostConfigParamsHandler = operations.PostConfigParamsHandlerFunc(handler.ConfigPostParams)

--- a/api/restapi/embedded_spec.go
+++ b/api/restapi/embedded_spec.go
@@ -1580,6 +1580,70 @@ func init() {
         }
       }
     },
+    "/config/endpointhoststate": {
+      "post": {
+        "description": "Sets the state of a host which can have multiple endpoints",
+        "summary": "Sets the state of a host",
+        "parameters": [
+          {
+            "description": "Attributes of end point",
+            "name": "attr",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EndPointHostState"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Malformed arguments for API call",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Invalid authentication credentials",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Capacity insufficient",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Resource Conflict.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal service error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "503": {
+            "description": "Maintenance mode",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/config/fdb": {
       "post": {
         "description": "Assign FDB in the device",
@@ -5885,6 +5949,27 @@ func init() {
         }
       }
     },
+    "EndPointHostState": {
+      "type": "object",
+      "properties": {
+        "epPort": {
+          "description": "The end-point port (0 if not applicable)",
+          "type": "integer"
+        },
+        "epProto": {
+          "description": "The end-point prototype (tcp,udp,sctp,icmp,http(s), empty if not applicable)",
+          "type": "string"
+        },
+        "hostName": {
+          "description": "Host name in CIDR",
+          "type": "string"
+        },
+        "state": {
+          "description": "Host state string (\"green\", \"yellow\", \"red\" )",
+          "type": "string"
+        }
+      }
+    },
     "EpDistTrafficMetrics": {
       "type": "object",
       "additionalProperties": {
@@ -8874,6 +8959,70 @@ func init() {
           },
           "409": {
             "description": "Resource Conflict. VLAN already exists OR dependency VRF/VNET not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal service error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "503": {
+            "description": "Maintenance mode",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/config/endpointhoststate": {
+      "post": {
+        "description": "Sets the state of a host which can have multiple endpoints",
+        "summary": "Sets the state of a host",
+        "parameters": [
+          {
+            "description": "Attributes of end point",
+            "name": "attr",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EndPointHostState"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Malformed arguments for API call",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Invalid authentication credentials",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Capacity insufficient",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "409": {
+            "description": "Resource Conflict.",
             "schema": {
               "$ref": "#/definitions/Error"
             }
@@ -13649,6 +13798,27 @@ func init() {
         },
         "probeType": {
           "description": "Type of probe used",
+          "type": "string"
+        }
+      }
+    },
+    "EndPointHostState": {
+      "type": "object",
+      "properties": {
+        "epPort": {
+          "description": "The end-point port (0 if not applicable)",
+          "type": "integer"
+        },
+        "epProto": {
+          "description": "The end-point prototype (tcp,udp,sctp,icmp,http(s), empty if not applicable)",
+          "type": "string"
+        },
+        "hostName": {
+          "description": "Host name in CIDR",
+          "type": "string"
+        },
+        "state": {
+          "description": "Host state string (\"green\", \"yellow\", \"red\" )",
           "type": "string"
         }
       }

--- a/api/restapi/handler/endpoint.go
+++ b/api/restapi/handler/endpoint.go
@@ -100,3 +100,19 @@ func ConfigDeleteEndPoint(params operations.DeleteConfigEndpointEpipaddressIPAdd
 	}
 	return &ResultResponse{Result: "Success"}
 }
+
+func ConfigPostEndPointHostState(params operations.PostConfigEndpointhoststateParams, principal interface{}) middleware.Responder {
+	tk.LogIt(tk.LogTrace, "api: EndPoint %s API called. url : %s\n", params.HTTPRequest.Method, params.HTTPRequest.URL)
+
+	EPHost := cmn.EndPointHostMod{}
+	EPHost.HostName = params.Attr.HostName
+	EPHost.EPPort = uint16(params.Attr.EpPort)
+	EPHost.EPProto = params.Attr.EpProto
+	EPHost.State = params.Attr.State
+
+	_, err := ApiHooks.NetEpHostStateSet(&EPHost)
+	if err != nil {
+		return &ResultResponse{Result: err.Error()}
+	}
+	return &ResultResponse{Result: "Success"}
+}

--- a/api/restapi/operations/loxilb_rest_api_api.go
+++ b/api/restapi/operations/loxilb_rest_api_api.go
@@ -300,6 +300,9 @@ func NewLoxilbRestAPIAPI(spec *loads.Document) *LoxilbRestAPIAPI {
 		PostConfigEndpointHandler: PostConfigEndpointHandlerFunc(func(params PostConfigEndpointParams, principal interface{}) middleware.Responder {
 			return middleware.NotImplemented("operation PostConfigEndpoint has not yet been implemented")
 		}),
+		PostConfigEndpointhoststateHandler: PostConfigEndpointhoststateHandlerFunc(func(params PostConfigEndpointhoststateParams, principal interface{}) middleware.Responder {
+			return middleware.NotImplemented("operation PostConfigEndpointhoststate has not yet been implemented")
+		}),
 		PostConfigFdbHandler: PostConfigFdbHandlerFunc(func(params PostConfigFdbParams, principal interface{}) middleware.Responder {
 			return middleware.NotImplemented("operation PostConfigFdb has not yet been implemented")
 		}),
@@ -571,6 +574,8 @@ type LoxilbRestAPIAPI struct {
 	PostConfigCistateHandler PostConfigCistateHandler
 	// PostConfigEndpointHandler sets the operation handler for the post config endpoint operation
 	PostConfigEndpointHandler PostConfigEndpointHandler
+	// PostConfigEndpointhoststateHandler sets the operation handler for the post config endpointhoststate operation
+	PostConfigEndpointhoststateHandler PostConfigEndpointhoststateHandler
 	// PostConfigFdbHandler sets the operation handler for the post config fdb operation
 	PostConfigFdbHandler PostConfigFdbHandler
 	// PostConfigFirewallHandler sets the operation handler for the post config firewall operation
@@ -940,6 +945,9 @@ func (o *LoxilbRestAPIAPI) Validate() error {
 	}
 	if o.PostConfigEndpointHandler == nil {
 		unregistered = append(unregistered, "PostConfigEndpointHandler")
+	}
+	if o.PostConfigEndpointhoststateHandler == nil {
+		unregistered = append(unregistered, "PostConfigEndpointhoststateHandler")
 	}
 	if o.PostConfigFdbHandler == nil {
 		unregistered = append(unregistered, "PostConfigFdbHandler")
@@ -1429,6 +1437,10 @@ func (o *LoxilbRestAPIAPI) initHandlerCache() {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
 	o.handlers["POST"]["/config/endpoint"] = NewPostConfigEndpoint(o.context, o.PostConfigEndpointHandler)
+	if o.handlers["POST"] == nil {
+		o.handlers["POST"] = make(map[string]http.Handler)
+	}
+	o.handlers["POST"]["/config/endpointhoststate"] = NewPostConfigEndpointhoststate(o.context, o.PostConfigEndpointhoststateHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2149,6 +2149,49 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  '/config/endpointhoststate':
+    post:
+      summary: Sets the state of a host
+      description: Sets the state of a host which can have multiple endpoints
+      parameters:
+        - name: attr
+          in: body
+          required: true
+          description: Attributes of end point
+          schema:
+            $ref: '#/definitions/EndPointHostState'
+      responses:
+        '204':
+          description: OK
+        '400':
+          description: Malformed arguments for API call
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: Invalid authentication credentials
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: Capacity insufficient
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Resource not found
+          schema:
+            $ref: '#/definitions/Error'
+        '409':
+          description: Resource Conflict.
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/Error'
+        '503':
+          description: Maintenance mode
+          schema:
+            $ref: '#/definitions/Error'
+
   '/config/endpoint/epipaddress/{ip_address}':
     delete:
       summary: Delete an LB end-point from monitoring
@@ -4452,6 +4495,22 @@ definitions:
       probePort:
         type: integer
         description: The l4port to probe on
+
+  EndPointHostState:
+    type: object
+    properties:
+      hostName:
+        type: string
+        description: Host name in CIDR
+      epPort:
+        type: integer
+        description: The end-point port (0 if not applicable)
+      epProto:
+        type: string
+        description: The end-point prototype (tcp,udp,sctp,icmp,http(s), empty if not applicable)
+      state:
+        type: string
+        description: Host state string ("green", "yellow", "red" )
 
   FirewallOptionEntry:
     type: object

--- a/common/common.go
+++ b/common/common.go
@@ -491,6 +491,29 @@ type EndPointMod struct {
 	CurrState string `json:"currState"`
 }
 
+const (
+	// HostStateGreen - Host is healthy
+	HostStateGreen = "green"
+	// HostStateYellow - Host is under load
+	HostStateYellow = "yellow"
+	// HostStateRed - Host is not healthy
+	HostStateRed = "red"
+	// HostStateUnknown - Host state is not known
+	HostStateUnknown = ""
+)
+
+// EndPointHostMod - Info related to an end-point host entry
+type EndPointHostMod struct {
+	// HostName - hostname in CIDR
+	HostName string `json:"hostName"`
+	// EPPort - The end-point port (0 if not applicable)
+	EPPort uint16 `json:"epPort"`
+	// EPProto - The end-point prototype (empty if not applicable)
+	EPProto string `json:"epProto"`
+	//  State - Host state string
+	State string `json:"state"`
+}
+
 // EpSelect - Selection method of load-balancer end-point
 type EpSelect uint
 
@@ -1096,6 +1119,7 @@ type NetHookInterface interface {
 	NetEpHostAdd(fm *EndPointMod) (int, error)
 	NetEpHostDel(fm *EndPointMod) (int, error)
 	NetEpHostGet() ([]EndPointMod, error)
+	NetEpHostStateSet(fm *EndPointHostMod) (int, error)
 	NetParamSet(param ParamMod) (int, error)
 	NetParamGet(param *ParamMod) (int, error)
 	NetGoBGPNeighGet() ([]GoBGPNeighGetMod, error)

--- a/pkg/loxinet/apiclient.go
+++ b/pkg/loxinet/apiclient.go
@@ -628,6 +628,19 @@ func (na *NetAPIStruct) NetEpHostGet() ([]cmn.EndPointMod, error) {
 	return ret, err
 }
 
+// NetEpHostStateSet - Set a host state (which can internally have multiple end-points)
+func (na *NetAPIStruct) NetEpHostStateSet(em *cmn.EndPointHostMod) (int, error) {
+	if na.BgpPeerMode {
+		return RuleUnknownEpErr, errors.New("running in bgp only mode")
+	}
+
+	mh.mtx.Lock()
+	defer mh.mtx.Unlock()
+
+	ret, err := mh.zr.Rules.SetEPHostState(em.HostName, em.EPPort, em.EPProto, em.State)
+	return ret, err
+}
+
 // NetParamSet - Set operational params of loxinet
 func (na *NetAPIStruct) NetParamSet(param cmn.ParamMod) (int, error) {
 	if na.BgpPeerMode {

--- a/pkg/loxinet/dpbroker.go
+++ b/pkg/loxinet/dpbroker.go
@@ -32,7 +32,7 @@ import (
 const (
 	MapNameCt4  = "CT4"
 	MapNameCt6  = "CT6"
-	MapNameNat4 = "NAT4"
+	MapNameNat  = "NAT"
 	MapNameBD   = "BD"
 	MapNameRxBD = "RXBD"
 	MapNameTxBD = "TXBD"

--- a/pkg/loxinet/dpebpf_linux.go
+++ b/pkg/loxinet/dpebpf_linux.go
@@ -1124,7 +1124,7 @@ func (e *DpEbpfH) DpStat(w *StatDpWorkQ) int {
 	var polTbl []int
 	sync := 0
 	switch {
-	case w.Name == MapNameNat4:
+	case w.Name == MapNameNat:
 		tbl = append(tbl, int(C.LL_DP_NAT_STATS_MAP))
 		sync = 1
 	case w.Name == MapNameBD:

--- a/pkg/loxinet/neighbor.go
+++ b/pkg/loxinet/neighbor.go
@@ -412,7 +412,7 @@ func (n *NeighH) NeighAdd(Addr net.IP, Zone string, Attr NeighAttr) (int, error)
 			}
 		}
 		//Instead of returning an error log, print an informational message
-                tk.LogIt(tk.LogInfo, "nh add - %s:%s exists\n", Addr.String(), Zone)
+		tk.LogIt(tk.LogInfo, "nh add - %s:%s exists\n", Addr.String(), Zone)
 		return NeighExistsErr, errors.New("nh exists")
 	}
 


### PR DESCRIPTION
The endpoint API now supports endpoint health state update. To set the health of the endpoint so that it is not selected in load-balancing - 
```
curl -X 'POST' \
  'http://172.17.0.3:11111/netlox/v1/config/endpointhoststate' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "hostName": "31.31.31.1",
  "epPort": 0,
  "epProto": "",
  "state": "red"
}'
```
Similarly, we can set state to "green" to indicate the endpoint health back to normal.