### PR TITLE
feat: Add manual token validation support

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -51,6 +51,10 @@ var Opts struct {
 	DatabasePasswordPath string         `long:"databasepasswordpath" description:"Database password" default:"/etc/loxilb/mysql_password"`
 	DatabaseName         string         `long:"databasename" description:"Database name" default:"loxilb_db"`
 
+	// manual token
+	ManualTokenEnable bool   `long:"manualtoken" description:"Enable manual token service for loxilb"`
+	ManualTokenPath   string `long:"manualtokenvalue" description:"Path of manual token " default:"/etc/loxilb/manual_token"`
+
 	// Oauth2 Options as input arguemtns
 	Oauth2Enable   bool   `long:"oauth2" description:"Enable user oauth2 service for loxilb"`
 	Oauth2Provider string `long:"oauth2provider" description:"Oauth2 provider names, comma-separated" default:"google"`


### PR DESCRIPTION
This pull request introduces a new feature for manual token validation in the authentication handler. The key changes include adding a new function for manual token validation, updating the `BearerAuthAuth` function to support this new validation method, and adding new configuration options for the manual token service.

### Authentication Enhancements:

* [`api/restapi/handler/auth.go`](diffhunk://#diff-83c672187036368b98e0eeb72403bfbd10c6cf6cb08c0a7cb236531717147a0fR117-R136): Added the `ManualTokenValidate` function to validate tokens based on a manually provided token file.
* [`api/restapi/handler/auth.go`](diffhunk://#diff-83c672187036368b98e0eeb72403bfbd10c6cf6cb08c0a7cb236531717147a0fR51-R53): Updated the `BearerAuthAuth` function to include a check for manual token validation if enabled.

### Configuration Updates:

* [`options/options.go`](diffhunk://#diff-76f121a3a81c8945dc0e0c81a4b95e941d252522eba8704a1aa6f6a1722a8b68R54-R57): Added new configuration options `ManualTokenEnable` and `ManualTokenPath` to enable and specify the path for the manual token file.

### Import Statements:

* [`api/restapi/handler/auth.go`](diffhunk://#diff-83c672187036368b98e0eeb72403bfbd10c6cf6cb08c0a7cb236531717147a0fR21): Added necessary imports for the new manual token validation functionality. [[1]](diffhunk://#diff-83c672187036368b98e0eeb72403bfbd10c6cf6cb08c0a7cb236531717147a0fR21) [[2]](diffhunk://#diff-83c672187036368b98e0eeb72403bfbd10c6cf6cb08c0a7cb236531717147a0fR31)