### PR TITLE
fix(terraform): Update provider versions for VPC and EKS modules

### DIFF
--- a/cicd/eks/terraform.tf
+++ b/cicd/eks/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.6.1"
+      version = "~> 6.0"
     }
 
     random = {


### PR DESCRIPTION
This pull request updates the infrastructure configuration for the EKS cluster by upgrading module and provider versions, modernizing the EKS setup, and improving node group and security group settings. The changes ensure compatibility with newer AWS features, improve scalability, and enhance security group management.

**Module and Provider Version Upgrades**
* Updated the `terraform-aws-modules/vpc/aws` module to version `5.8.1` for improved VPC features and compatibility.
* Upgraded the `terraform-aws-modules/eks/aws` module to version `~> 21.0` and set the Kubernetes version to `1.33` for access to newer EKS capabilities.
* Increased the `terraform-aws-modules/security-group/aws` module version to `5.3.0` for enhanced security group management.
* Updated the AWS provider version constraint to `~> 6.0` for broader compatibility and access to the latest provider features.

**EKS Cluster Configuration Improvements**
* Changed EKS cluster configuration to use new `name` and `kubernetes_version` fields, added managed addons (`coredns`, `eks-pod-identity-agent`, `kube-proxy`, `vpc-cni`), enabled cluster creator admin permissions, and modernized node group setup with larger instance types and enhanced security group associations.

**Minor Cleanup**
* Removed extraneous whitespace after the security group rule resource.