### PR TITLE
fix: Improve BFD session handling in NetBFDGet function

### DIFF
--- a/pkg/loxinet/apiclient.go
+++ b/pkg/loxinet/apiclient.go
@@ -533,9 +533,14 @@ func (na *NetAPIStruct) NetBFDGet() ([]cmn.BFDMod, error) {
 		return nil, errors.New("running in bgp only mode")
 	}
 	mh.mtx.Lock()
-	defer mh.mtx.Unlock()
-
-	return mh.has.CIBFDSessionGet()
+	if !mh.has.SpawnKa || mh.has.Bs == nil {
+		mh.mtx.Unlock()
+		tk.LogIt(tk.LogError, "[CLUSTER] BFD sessions not running\n")
+		return nil, errors.New("bfd session not running")
+	}
+	bp := mh.has.Bs
+	mh.mtx.Unlock()
+	return bp.BFDGet()
 }
 
 // NetBFDAdd - Add BFD Session


### PR DESCRIPTION
This pull request refactors the logic for retrieving BFD sessions in the `NetAPIStruct` API client. The main change is to improve deadlock handling and ensure that BFD sessions are properly checked before attempting to retrieve them.

Improvements to error handling and session validation:

* Added checks for `SpawnKa` and `Bs` before accessing BFD sessions, returning an error and logging if sessions are not running. (`pkg/loxinet/apiclient.go`, [pkg/loxinet/apiclient.goL536-R543](diffhunk://#diff-2ff4ee14bfcdb79c7f8f819e9757e048dc4c577815951b8f844bd91a7ce988d4L536-R543))
* Replaced the previous call to `CIBFDSessionGet()` with a direct call to `BFDGet()` on the `Bs` object, ensuring the correct session retrieval method is used. (`pkg/loxinet/apiclient.go`, [pkg/loxinet/apiclient.goL536-R543](diffhunk://#diff-2ff4ee14bfcdb79c7f8f819e9757e048dc4c577815951b8f844bd91a7ce988d4L536-R543))