### PR TITLE
chore: bump version to 0.9.8.6-beta

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	Version = "0.9.8.5-beta"
+	Version = "0.9.8.6-beta"
 )
 
 var BuildInfo string = ""


### PR DESCRIPTION
## Release v0.9.8.6

Bump version string for the v0.9.8.6 release.

### Changes since v0.9.8.5
- **Fix:** SCTP closed/shutdown state-machine recovery (loxilb-ebpf submodule bump)
- Build housekeeping (Dockerfile/Makefile `make clean`)

### Notes
- Single-line change in `common/common.go` (`0.9.8.5-beta` → `0.9.8.6-beta`)
- No untracked/local working-tree files are included.