### PR TITLE
loxinet: reset endpoint probe failure counter (inActTries) on every successful probe

### DIFF
--- a/pkg/loxinet/rules.go
+++ b/pkg/loxinet/rules.go
@@ -2626,9 +2626,15 @@ func (R *RuleH) SetEPHostState(hostName string, epPort uint16, epProto string, s
 
 func (ep *epHost) transitionEPState(currState bool, inactThr int) {
 	if currState {
+		// Reset the failure counter on ANY successful probe, not only when
+		// transitioning back from inactive. Otherwise inActTries accumulates
+		// across the endpoint's entire active lifetime, so sporadic, non-
+		// consecutive probe misses eventually trip inactThr and flap a healthy
+		// endpoint to inactive. proberetries is documented as the number of
+		// retries before marking an endpoint inactive (consecutive failures).
+		ep.inActTries = 0
 		if ep.inactive {
 			ep.inactive = false
-			ep.inActTries = 0
 			ep.opts.currProbeDuration = ep.opts.probeDuration
 			tk.LogIt(tk.LogDebug, "active ep - %s:%s:%d(%v)\n",
 				ep.epKey, ep.opts.probeType, ep.opts.probePort, ep.avgDelay)


### PR DESCRIPTION
### Problem

`proberetries` (CLI `--retries`, k8s `loxilb.io/proberetries`) is documented as
"the number of retries before marking an endPoint inactive", which implies
**consecutive** failed probes. In practice it counts **cumulative** failures over
the endpoint's whole active lifetime.

In `transitionEPState`, `inActTries` is incremented on every failed probe, but it
is only reset **inside the `if ep.inactive` branch** — i.e. only after the endpoint
has already crossed the threshold and gone down:

```go
func (ep *epHost) transitionEPState(currState bool, inactThr int) {
	if currState {
		if ep.inactive {            // reset happens ONLY here
			ep.inactive = false
			ep.inActTries = 0
			...
		}
	} else {
		if ep.inActTries < inactThr {
			ep.inActTries++
			if ep.inActTries >= inactThr { ep.inactive = true }
		} else { ep.inActTries++ ; ... }
	}
}
```

While the endpoint is still `active` (`ep.inactive == false`), a **successful probe
does not reset `inActTries`**. So:

- a single transient miss bumps the counter to 1 and it stays there,
- subsequent successes never clear it,
- after `proberetries` such misses — *no matter how far apart in time* — the
  endpoint flaps to `inactive`, then recovers on the very next successful probe.

### Impact

On a busy / contended deployment (e.g. multiple loxilb instances each probing the
same SCTP backend), occasional isolated probe drops are normal. With the default
`proberetries=2`, just two non-consecutive drops — possibly hours apart — take a
healthy endpoint out of rotation briefly, causing intermittent connection drops
that are very hard to diagnose. Raising `proberetries` only delays it.

### Fix

Reset `inActTries` on **every** successful probe, so the threshold counts
consecutive failures as documented. The existing reset on the inactive→active
transition becomes a subset of this and is preserved.

```go
func (ep *epHost) transitionEPState(currState bool, inactThr int) {
	if currState {
		// Reset the failure counter on ANY successful probe, not only when
		// transitioning back from inactive. Otherwise inActTries accumulates
		// across the endpoint's entire active lifetime, so sporadic, non-
		// consecutive probe misses eventually trip inactThr and flap a healthy
		// endpoint to inactive.
		ep.inActTries = 0
		if ep.inactive {
			ep.inactive = false
			ep.opts.currProbeDuration = ep.opts.probeDuration
			tk.LogIt(tk.LogDebug, "active ep - %s:%s:%d(%v)\n",
				ep.epKey, ep.opts.probeType, ep.opts.probePort, ep.avgDelay)
		}
	} else {
		// unchanged
	}
}
```

### Behavior change

- Before: `proberetries` = cumulative lifetime failures before going inactive.
- After: `proberetries` = consecutive failures before going inactive (matches docs).
- A genuinely dead endpoint still trips after `proberetries` consecutive failed
  probes; only the false-positive flapping on a healthy endpoint is removed.

### Testing

- Built loxilb with the patch, ran an SCTP endpoint with `proberetries=2`.
- Injected isolated single probe drops (block the probe once, then allow): endpoint
  stays `ok` (counter resets each success) — before the patch it would reach
  `nok` after 2 such drops regardless of spacing.
- Injected 2 consecutive drops: endpoint correctly goes `nok`, then `ok` after a
  successful probe. No regression in dead-endpoint detection.