### PR TITLE
fullproxy: PROXY protocol v2 (source IP preservation, GSO-safe)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 **/.git
+cicd/

--- a/cicd/tlsproxyprotov2/README.md
+++ b/cicd/tlsproxyprotov2/README.md
@@ -1,0 +1,81 @@
+# tlsproxyprotov2 — TLS 1.3 + PROXY protocol v2 reproduction
+
+Reproduces loxilb Issue **#1044** / Discussion **#1089**: with a load balancer in
+`fullnat` mode and PROXY protocol v2 enabled (`--ppv2en`), the **TLS 1.3 handshake
+fails** while TLS 1.2 works.
+
+Root-cause analysis: [`../../docs/tls13-proxyproto-v2-issue/`](../../docs/tls13-proxyproto-v2-issue/).
+The bug is in the eBPF L4 datapath `dp_ins_ppv2()`, which inserts the 28-byte PROXY v2
+header into the first TCP data packet (the TLS ClientHello) with
+`bpf_skb_adjust_room(..., BPF_F_ADJ_ROOM_FIXED_GSO)`. **When that packet is a GSO
+super-packet (`gso_size>0`) the insertion corrupts the byte stream**, so the backend
+can't parse the PROXY header / TLS record and the handshake dies right after ClientHello.
+
+## Reproduced (2026-07-15) — pure docker/veth
+
+Earlier this scenario was a *passing baseline* because at the default MTU the ClientHello
+fits in one segment (`< MSS`) → it is never a GSO skb → the `FIXED_GSO` path is never
+taken. `validation.sh` now **forces the GSO path** and reproduces the bug:
+
+1. Shrink the client's send-MSS to the VIP (small per-route PMTU, `REPRO_MTU=320` → MSS ~256).
+2. Inflate the TLS 1.3 ClientHello past that MSS (long `-servername`, ~500 B).
+
+so the client's GSO builds a `gso_size>0` super-packet for the ClientHello.
+
+### The control makes it decisive (it is GSO, not MTU/PMTU)
+
+| case | condition | result |
+|------|-----------|--------|
+| CONTROL-1 | default MTU, offload ON — hello is single-segment | **OK** |
+| CONTROL-2 | `MTU=320`, offload **OFF** — real multi-segment, not GSO | **OK** |
+| REPRO     | `MTU=320`, offload **ON** — GSO super-packet ClientHello | **FAIL** |
+
+Same MTU, same hello: only client segmentation-offload differs. Offload OFF (real
+separate segments) succeeds; offload ON (one GSO super-packet) fails. That rules out
+"small MTU / PMTU" and pins the failure on GSO super-packet handling in `dp_ins_ppv2`.
+
+### Client-observed symptom
+
+With the nginx backend (`listen ... ssl proxy_protocol`), the client sees the handshake
+die immediately after ClientHello:
+- `openssl s_client -tls1_3` → connection stalls, then closes (the **`SSL_ERROR_SYSCALL`**
+  form reported in Discussion #1089).
+- backend nginx logs: `broken header: "" while reading PROXY protocol` — proof the bytes
+  reached the backend but the inserted PROXY header was corrupted.
+
+> Note on the exact #1044 string: `error:0A00042E:...ssl3_read_bytes:tlsv1 alert protocol
+> version` is emitted when the backend gets *past* the PROXY header but then reads a
+> byte-shifted TLS record. Here nginx rejects earlier, at the PROXY-parse stage
+> (`broken header`), so it closes the connection instead of sending that TLS alert.
+> Both are the **same root cause** (GSO + `dp_ins_ppv2`); which one you see depends on
+> where the GSO corruption lands and how the backend (nginx vs Traefik) reacts.
+
+## Run
+
+```
+cd cicd/tlsproxyprotov2/
+./config.sh          # topology + nginx(proxy_protocol,TLS1.2/1.3) + fullnat/ppv2 rule
+./validation.sh      # prints CONTROL-1/CONTROL-2/REPRO and REPRODUCED/NOT
+./rmconfig.sh
+```
+
+Knob: `REPRO_MTU=<n> ./validation.sh` to change the forced client PMTU.
+
+## Topology / what it exercises (vs cicd/httpsproxy)
+
+- `llb1` runs in **normal eBPF mode** (no `--proxyonlymode`) → the fast-path `dp_ins_ppv2` runs.
+- LB rule is `--mode=fullnat --ppv2en` (no `--security`) → loxilb does **not** terminate TLS.
+- Backends run **nginx** with `listen 8080 ssl proxy_protocol;` (TLS 1.2 + 1.3): nginx strips
+  the PROXY header loxilb inserts, then terminates TLS. Mirrors the real-world reports
+  (nginx / Traefik). This is deliberately different from `cicd/httpsproxy`
+  (`--mode=fullproxy --security=https`, the L7 OpenSSL path, which would mask the bug).
+
+> Debugging trap: `llb1` is `--privileged`, so `docker exec llb1 ip link set <veth> mtu <N>`
+> succeeds. Accidentally lowering an llb1 veth MTU blackholes the backend's larger response
+> and looks like a datapath bug — it isn't. Restore MTU 9000.
+
+## CI status
+
+RED until #1044 is fixed (this scenario now exits non-zero when the bug is NOT reproduced,
+i.e. after a fix it must be updated to expect success). Not yet wired into a GitHub workflow;
+run manually, or promote to a sanity workflow once the eBPF fix lands.

--- a/cicd/tlsproxyprotov2/build_deploy.sh
+++ b/cicd/tlsproxyprotov2/build_deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Build the eBPF datapath from local source with the loxilb toolchain (clang 10 in
+# ossca-build), bake into a derived image, and rebuild the testbed.
+# Usage: sudo ./build_deploy.sh
+set -e
+# repo root = three levels up from this script (cicd/tlsproxyprotov2/)
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+KDIR=$ROOT/loxilb-ebpf/kernel
+
+echo "== [1/4] build .o in ossca-build (clang 10) =="
+# NOTE: the Makefile does NOT list llb_kern_cdefs.h as a prerequisite, so editing
+# that header alone does NOT trigger a rebuild. Force it by removing the objects.
+rm -f $KDIR/llb_ebpf_main.o $KDIR/llb_ebpf_emain.o
+docker run --rm -v $ROOT/loxilb-ebpf:/be --entrypoint /bin/bash ghcr.io/loxilb-io/ossca-build:latest \
+  -c "cd /be/kernel && rm -f llb_ebpf_main.o llb_ebpf_emain.o && make llb_ebpf_main.o llb_ebpf_emain.o 2>&1 | grep -iE 'error|clang' | head"
+test -f $KDIR/llb_ebpf_main.o
+echo "   PPV2DBG symbols in built .o: $(strings $KDIR/llb_ebpf_main.o 2>/dev/null | grep -c PPV2DBG)"
+
+echo "== [2/4] build derived image loxilb:ppv2test =="
+rm -rf /tmp/ppv2img; mkdir -p /tmp/ppv2img
+cp $KDIR/llb_ebpf_main.o $KDIR/llb_ebpf_emain.o /tmp/ppv2img/
+printf 'FROM ghcr.io/loxilb-io/loxilb:latest\nCOPY llb_ebpf_main.o llb_ebpf_emain.o /opt/loxilb/\n' > /tmp/ppv2img/Dockerfile
+docker build -t loxilb:ppv2test /tmp/ppv2img >/dev/null 2>&1
+echo "   image built"
+
+echo "== [3/4] rebuild testbed =="
+cd $ROOT/cicd/tlsproxyprotov2
+./rmconfig.sh >/dev/null 2>&1
+LOXILB_IMAGE=loxilb:ppv2test ./config.sh >config.run.log 2>&1
+grep -q "Setup done" config.run.log && echo "   testbed up" || { echo "   CONFIG FAILED"; tail -5 config.run.log; exit 1; }
+
+echo "== [4/4] done. run ./validation.sh or ./trace_repro.sh =="

--- a/cicd/tlsproxyprotov2/config.sh
+++ b/cicd/tlsproxyprotov2/config.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# Reproduction scenario for Issue #1044 / Discussion #1089:
+#   "TLS 1.3 handshake fails when PROXY protocol v2 is enabled"
+#
+# Topology (mirrors cicd/httpsproxy) but with two crucial differences so the
+# eBPF L4 datapath (dp_ins_ppv2) is exercised instead of the L7 sockproxy path:
+#   1. llb1 runs in NORMAL eBPF mode (NO --proxyonlymode).
+#   2. LB rule is  --mode=fullnat --ppv2en  (NOT fullproxy / --security).
+#
+# loxilb does NOT terminate TLS here. Each backend runs nginx with
+# 'listen ... ssl proxy_protocol' which strips the PROXY v2 header loxilb
+# inserts, then terminates TLS (1.2 + 1.3). See ../../docs/tls13-proxyproto-v2-issue/.
+
+source ../common.sh
+
+# Allow overriding the loxilb image (e.g. a locally-built one carrying a patched
+# eBPF datapath) without editing common.sh:  LOXILB_IMAGE=loxilb:ppv2test ./config.sh
+lxdocker="${LOXILB_IMAGE:-$lxdocker}"
+echo "Using loxilb image: $lxdocker"
+
+echo "#########################################"
+echo "Spawning all hosts"
+echo "#########################################"
+
+# NOTE: no --proxyonlymode -> loxilb loads the full tc/eBPF datapath.
+# Override with LOXILB_EXTRA (e.g. LOXILB_EXTRA="--proxyonlymode") to test fullproxy.
+if [[ -n "$LOXILB_EXTRA" ]]; then
+  spawn_docker_host --dock-type loxilb --dock-name llb1 --extra-args "$LOXILB_EXTRA"
+else
+  spawn_docker_host --dock-type loxilb --dock-name llb1
+fi
+spawn_docker_host --dock-type host --dock-name l3h1
+spawn_docker_host --dock-type host --dock-name l3ep1
+spawn_docker_host --dock-type host --dock-name l3ep2
+spawn_docker_host --dock-type host --dock-name l3ep3
+
+echo "#########################################"
+echo "Installing nginx on endpoints (parallel)"
+echo "#########################################"
+
+eps=( l3ep1 l3ep2 l3ep3 )
+names=( server1 server2 server3 )
+
+# IMPORTANT: install BEFORE the network is reconfigured. At spawn time the host
+# containers still default-route via docker0 (eth0, NAT internet). Once
+# config_docker_host sets the default gw to the loxilb veth, the endpoints lose
+# internet (they sit on the isolated data network), so apt would hang.
+# Install nginx only if the nettest image doesn't already ship it
+# (precedent: cicd/egresslb, cicd/ipsec-e2e install packages via $dexec).
+# Run all three in parallel so the apt cost is ~1x, not 3x.
+for ep in "${eps[@]}"; do
+  $dexec "$ep" bash -c "command -v nginx >/dev/null 2>&1 || (apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nginx)" \
+    > "apt.${ep}.log" 2>&1 &
+done
+echo "Waiting for nginx installs to finish..."
+wait
+for ep in "${eps[@]}"; do
+  if ! $dexec "$ep" sh -c "command -v nginx >/dev/null 2>&1"; then
+    echo "ERROR: nginx install failed on $ep (see apt.${ep}.log):"
+    tail -5 "apt.${ep}.log"
+    exit 1
+  fi
+done
+echo "nginx installed on all endpoints"
+
+# Install ethtool on client + loxilb (best effort) so validation.sh can toggle
+# tso/gso/gro. Done NOW while docker0 internet is still reachable (before the
+# default route is moved onto the loxilb veth by config_docker_host below).
+$dexec l3h1 bash -c "command -v ethtool >/dev/null 2>&1 || (apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ethtool)" >apt.l3h1.log 2>&1 &
+$dexec llb1 bash -c "command -v ethtool >/dev/null 2>&1 || (apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ethtool)" >apt.llb1.log 2>&1 &
+wait
+$dexec l3h1 sh -c "command -v ethtool" >/dev/null 2>&1 && echo "ethtool on l3h1" || echo "WARN: ethtool missing on l3h1 (offload toggles will be skipped)"
+
+echo "#########################################"
+echo "Connecting and configuring  hosts"
+echo "#########################################"
+
+connect_docker_hosts l3h1 llb1
+connect_docker_hosts l3ep1 llb1
+connect_docker_hosts l3ep2 llb1
+connect_docker_hosts l3ep3 llb1
+
+sleep 5
+
+#L3 config
+config_docker_host --host1 l3h1 --host2 llb1 --ptype phy --addr 10.10.10.1/24 --gw 10.10.10.254
+config_docker_host --host1 l3ep1 --host2 llb1 --ptype phy --addr 31.31.31.1/24 --gw 31.31.31.254
+config_docker_host --host1 l3ep2 --host2 llb1 --ptype phy --addr 32.32.32.1/24 --gw 32.32.32.254
+config_docker_host --host1 l3ep3 --host2 llb1 --ptype phy --addr 33.33.33.1/24 --gw 33.33.33.254
+config_docker_host --host1 llb1 --host2 l3h1 --ptype phy --addr 10.10.10.254/24
+config_docker_host --host1 llb1 --host2 l3ep1 --ptype phy --addr 31.31.31.254/24
+config_docker_host --host1 llb1 --host2 l3ep2 --ptype phy --addr 32.32.32.254/24
+config_docker_host --host1 llb1 --host2 l3ep3 --ptype phy --addr 33.33.33.254/24
+
+$dexec llb1 ip addr add 10.10.10.3/32 dev lo
+
+echo "#########################################"
+echo "Generating backend TLS certificate"
+echo "#########################################"
+
+# Cert is issued for the VIP the client dials (10.10.10.254) and lives on the
+# BACKENDS (nginx terminates TLS). Client uses curl --insecure.
+rm -fr 10.10.10.254 minica*.pem
+./minica -ip-addresses 10.10.10.254
+cp 10.10.10.254/cert.pem 10.10.10.254/server.crt
+cp 10.10.10.254/key.pem  10.10.10.254/server.key
+
+echo "#########################################"
+echo "Configuring & starting nginx (proxy_protocol + TLS)"
+echo "#########################################"
+
+for i in "${!eps[@]}"; do
+  ep="${eps[$i]}"
+  name="${names[$i]}"
+
+  # Render the config template with this backend's identifier.
+  sed "s/__NAME__/${name}/" nginx.conf.tmpl > "nginx.${ep}.conf"
+
+  # Push config + cert into the container, then (re)start nginx.
+  $dexec "$ep" mkdir -p /etc/nginx/certs
+  docker cp "nginx.${ep}.conf"       "${ep}:/etc/nginx/nginx.conf"
+  docker cp 10.10.10.254/server.crt  "${ep}:/etc/nginx/certs/server.crt"
+  docker cp 10.10.10.254/server.key  "${ep}:/etc/nginx/certs/server.key"
+
+  $dexec "$ep" nginx -s stop 2>/dev/null
+  $dexec "$ep" nginx -t
+  $dexec "$ep" nginx
+done
+
+sleep 5
+
+echo "#########################################"
+echo "Creating LB rule: fullnat + PROXY protocol v2 (--ppv2en)"
+echo "#########################################"
+
+# --ppv2en enables PROXY protocol v2 (eBPF inserts the header).
+# --mode=fullnat routes via the eBPF NAT path -> CT -> dp_ins_ppv2.
+# No --security: loxilb does NOT terminate TLS (backends do).
+# create_lb_rule runs a tc_packet_func hook check for non-fullproxy modes,
+# which fails hard if the eBPF datapath isn't loaded.
+create_lb_rule llb1 10.10.10.254 --tcp=2020:8080 --endpoints=31.31.31.1:1,32.32.32.1:1,33.33.33.1:1 --mode=fullnat --ppv2en
+
+echo "#########################################"
+echo "Setup done"
+echo "#########################################"

--- a/cicd/tlsproxyprotov2/nginx.conf.tmpl
+++ b/cicd/tlsproxyprotov2/nginx.conf.tmpl
@@ -1,0 +1,31 @@
+worker_processes 1;
+error_log /var/log/nginx/error.log warn;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    access_log off;
+
+    server {
+        # 'proxy_protocol' makes nginx expect and strip a PROXY protocol (v1/v2)
+        # header at the start of every connection; 'ssl' then terminates TLS.
+        # loxilb (fullnat + --ppv2en) inserts the PROXY v2 header inline into the
+        # first TCP data packet (the TLS ClientHello) via the eBPF dp_ins_ppv2().
+        listen 8080 ssl proxy_protocol;
+
+        ssl_certificate     /etc/nginx/certs/server.crt;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+
+        # Serve BOTH versions from one backend so the same server answers the
+        # TLS 1.2 control probe and the TLS 1.3 regression probe.
+        ssl_protocols       TLSv1.2 TLSv1.3;
+
+        location / {
+            default_type text/plain;
+            return 200 "__NAME__";
+        }
+    }
+}

--- a/cicd/tlsproxyprotov2/rmconfig.sh
+++ b/cicd/tlsproxyprotov2/rmconfig.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source ../common.sh
+
+# Best-effort stop of the backend nginx instances.
+for ep in l3ep1 l3ep2 l3ep3; do
+  $dexec "$ep" nginx -s stop 2>/dev/null || true
+done
+
+disconnect_docker_hosts l3h1 llb1
+disconnect_docker_hosts l3ep1 llb1
+disconnect_docker_hosts l3ep2 llb1
+disconnect_docker_hosts l3ep3 llb1
+
+delete_docker_host llb1
+delete_docker_host l3h1
+delete_docker_host l3ep1
+delete_docker_host l3ep2
+delete_docker_host l3ep3
+
+rm -rf 10.10.10.254/ minica.pem minica-key.pem nginx.l3ep*.conf apt.l3ep*.log
+
+echo "#########################################"
+echo "Deleted testbed"
+echo "#########################################"

--- a/cicd/tlsproxyprotov2/validation.sh
+++ b/cicd/tlsproxyprotov2/validation.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Reproduction of Issue #1044 / Discussion #1089:
+#   TLS 1.3 handshake fails when PROXY protocol v2 is enabled.
+#
+# ROOT CAUSE (reproduced here, pure docker/veth): the eBPF dp_ins_ppv2() inserts
+# the 28-byte PROXY v2 header into the first TCP data packet (the TLS ClientHello)
+# using bpf_skb_adjust_room(..., BPF_F_ADJ_ROOM_FIXED_GSO). When that packet is a
+# GSO super-packet (gso_size>0) the insertion corrupts the byte stream, so the
+# backend cannot parse the PROXY header / TLS record -> handshake dies right after
+# ClientHello.  See ../../docs/tls13-proxyproto-v2-issue/.
+#
+# The baseline scenario never reproduced this because at the default MTU the
+# ClientHello fits in ONE segment (< MSS) => not a GSO skb => the FIXED_GSO path is
+# never taken. This script FORCES the GSO path in veth with two knobs:
+#   1. Shrink the client's send-MSS to the VIP (small per-route PMTU) AND
+#   2. Inflate the ClientHello past that MSS (long SNI),
+# so the client's GSO builds a gso_size>0 super-packet for the hello.
+#
+# The control is decisive: with client segmentation-offload OFF (real separate
+# segments, same small MSS) the handshake SUCCEEDS; only with offload ON (GSO
+# super-packet) does it FAIL. That rules out "small MTU / PMTU" as the cause and
+# pins it on the GSO super-packet handling in dp_ins_ppv2.
+
+source ../common.sh
+echo SCENARIO-tlsproxyprotov2
+
+vip="10.10.10.254"; vport="2020"; servers="server1 server2 server3"
+CLIENT_IF="el3h1llb1"; LLB_CLIENT_IF="ellb1l3h1"; LLB_EP1_IF="ellb1l3ep1"; EP_IF="el3ep1llb1"
+
+# Long SNI inflates the TLS 1.3 ClientHello (~500B) past the small MSS below.
+SNI="$(head -c 180 </dev/zero | tr '\0' a).loxilb.io"
+REPRO_MTU="${REPRO_MTU:-320}"     # client->VIP PMTU: MSS ~256, hello ~500 => GSO skb
+ERR_RE='tlsv1 alert protocol version|alert number 70|:0A00042E:'
+
+setmtu() { $hexec l3h1 ip route del ${vip}/32 2>/dev/null; [[ -n "$1" ]] && $hexec l3h1 ip route replace ${vip}/32 dev $CLIENT_IF mtu $1 2>/dev/null; }
+setoff() { # $1=on|off on the whole client<->loxilb<->backend path
+  $hexec l3h1  ethtool -K $CLIENT_IF     tso $1 gso $1 gro $1 2>/dev/null
+  $hexec llb1  ethtool -K $LLB_CLIENT_IF tso $1 gso $1 gro $1 2>/dev/null
+  $hexec llb1  ethtool -K $LLB_EP1_IF    tso $1 gso $1 gro $1 2>/dev/null
+  $hexec l3ep1 ethtool -K $EP_IF         tso $1 gso $1 gro $1 2>/dev/null
+}
+is_server() { for s in $servers; do [[ "$1" == "$s" ]] && return 0; done; return 1; }
+
+# openssl s_client probe -> prints raw output. $1 = -tls1_3|-tls1_2
+oprobe() { $hexec l3h1 bash -c "timeout 10 openssl s_client $1 -servername '$SNI' -connect ${vip}:${vport} </dev/null 2>&1"; }
+# returns OK|ALERT|FAIL
+oclass() {
+  echo "$1" | grep -qiE "$ERR_RE" && { echo ALERT; return; }
+  echo "$1" | grep -qiE "New, TLSv1|handshake has read [1-9]" && { echo OK; return; }
+  echo FAIL   # empty output => stalled then closed by backend
+}
+
+echo "SNI len=${#SNI}  repro MTU=${REPRO_MTU}"
+echo "ethtool on client? $($hexec l3h1 sh -c 'command -v ethtool >/dev/null && echo yes || echo NO')"
+
+# ---------- CONTROL 1: default path (single-segment hello) must work ----------
+echo "=================================================================="
+echo "CONTROL-1  default MTU, offload ON  (hello is single-segment)"
+echo "=================================================================="
+setoff on; setmtu ""
+c12=$(oprobe -tls1_2); c13=$(oprobe -tls1_3)
+echo "  TLS1.2 -> $(oclass "$c12")   TLS1.3 -> $(oclass "$c13")"
+base_ok=0; [[ "$(oclass "$c13")" == OK ]] && base_ok=1
+
+# ---------- CONTROL 2: small MSS + multi-segment, offload OFF -> should WORK ----
+echo "=================================================================="
+echo "CONTROL-2  MTU=$REPRO_MTU, offload OFF  (real multi-segment, NOT GSO)"
+echo "=================================================================="
+setoff off; setmtu $REPRO_MTU
+off_out=$(oprobe -tls1_3); off_cls=$(oclass "$off_out")
+echo "  TLS1.3 -> $off_cls   $(echo "$off_out" | grep -oiE 'handshake has read [0-9]+ bytes' | head -1)"
+
+# ---------- REPRO: same MTU, offload ON -> GSO super-packet -> should FAIL ------
+echo "=================================================================="
+echo "REPRO      MTU=$REPRO_MTU, offload ON   (GSO super-packet ClientHello)"
+echo "=================================================================="
+setoff on; setmtu $REPRO_MTU
+on_out=$(oprobe -tls1_3); on_cls=$(oclass "$on_out")
+echo "  openssl TLS1.3 -> $on_cls"
+[[ "$on_cls" == FAIL ]] && echo "     (client stalled/closed right after ClientHello -> SSL_ERROR_SYSCALL form, #1089)"
+[[ "$on_cls" == ALERT ]] && { echo "     >>> exact #1044 alert observed:"; echo "$on_out" | grep -iE "$ERR_RE|read .*bytes|written .*bytes" | sed 's/^/       /'; }
+# NOTE: a plain `curl https://vip` is NOT a good probe here - curl sends no SNI to
+# an IP literal, so its ClientHello stays small (< MSS) and single-segment, i.e. it
+# does NOT trigger the GSO path. openssl with the long -servername above is what
+# inflates the hello past the MSS. Use openssl to reproduce.
+
+# ---------- backend evidence ----------
+echo "------------------------------------------------------------------"
+echo "backend nginx PROXY-parse errors (proof bytes reached backend, header corrupt):"
+$dexec l3ep1 tail -n 3 /var/log/nginx/error.log 2>/dev/null | grep -i "proxy" | sed 's/^/  /'
+
+# ---------- verdict ----------
+setoff on; setmtu ""
+echo "=================================================================="
+verdict=1
+if [[ "$on_cls" != OK && "$off_cls" == OK && $base_ok == 1 ]]; then
+  echo "RESULT: REPRODUCED #1044/#1089."
+  echo "  - single-segment hello (CONTROL-1): OK"
+  echo "  - multi-segment, offload OFF (CONTROL-2): OK   <- not a PMTU/MTU problem"
+  echo "  - GSO super-packet, offload ON  (REPRO):  $on_cls  <- dp_ins_ppv2 FIXED_GSO corruption"
+  verdict=0
+elif [[ $base_ok != 1 ]]; then
+  echo "RESULT: inconclusive - even the single-segment control failed (env/routing issue)."
+else
+  echo "RESULT: NOT reproduced (offload-ON case did not fail as expected). on=$on_cls off=$off_cls"
+fi
+echo "=================================================================="
+
+if [[ $verdict == 0 ]]; then echo SCENARIO-tlsproxyprotov2 [OK] "(bug reproduced)"; else echo SCENARIO-tlsproxyprotov2 [FAILED] "(not reproduced)"; fi
+exit $verdict


### PR DESCRIPTION
Enables `--mode=fullproxy --ppv2en` to convey the original client IP to the backend via a PROXY protocol v2 header, as a GSO-safe alternative to `fullnat + ppv2`.

## Commits
1. **loxilb-ebpf submodule bump** → userspace PPv2 insertion in `sockproxy` (see loxilb-io/loxilb-ebpf#86). The header is written at the TCP stream level (first bytes of each backend connection, before backend TLS), so it is immune to the GSO corruption that affects the eBPF `fullnat+ppv2` inline insertion (#1044, #1089).
2. **docker: exclude `cicd/` from build context** — `make docker` failed loading the context on root-owned, unreadable cert files left by sudo-run cicd scenarios; `cicd/` is not needed for the image build.
3. **cicd: tlsproxyprotov2 scenario** — reproduces the `fullnat+ppv2` TLS 1.3 failure by forcing the GSO super-packet path and contrasting client offload on/off.

## Depends on
- loxilb-io/loxilb-ebpf#86 — the submodule pointer here (`84fcb5f`) references that branch; merge it first (preserving the SHA, or re-point this bump to the merged SHA) so the submodule stays resolvable after merge.

## Verified
- Backend (nginx `ssl proxy_protocol`) receives a valid PPv2 header with the real client IP; TLS 1.3 handshake succeeds — including with client offload ON + small MTU (GSO), the exact condition that breaks `fullnat+ppv2`.
- IPv4/TCP only for now; IPv6 is a follow-up.

Relates to #1044, #1089.

🤖 Generated with [Claude Code](https://claude.com/claude-code)