### PR TITLE
ebpf: fix fullnat+ppv2 GSO stream corruption (TLS 1.3 + PROXY v2 failures)

### DIFF
--- a/cicd/tlsproxyprotov2/validation.sh
+++ b/cicd/tlsproxyprotov2/validation.sh
@@ -91,10 +91,25 @@ echo "backend nginx PROXY-parse errors (proof bytes reached backend, header corr
 $dexec l3ep1 tail -n 3 /var/log/nginx/error.log 2>/dev/null | grep -i "proxy" | sed 's/^/  /'
 
 # ---------- verdict ----------
+# EXPECT=bug   (default): assert the bug REPRODUCES (pre-fix baseline).
+# EXPECT=fixed          : assert the GSO case now PASSES (post-fix regression gate).
+EXPECT="${EXPECT:-bug}"
 setoff on; setmtu ""
 echo "=================================================================="
 verdict=1
-if [[ "$on_cls" != OK && "$off_cls" == OK && $base_ok == 1 ]]; then
+if [[ "$EXPECT" == "fixed" ]]; then
+  if [[ "$on_cls" == OK && "$off_cls" == OK && $base_ok == 1 ]]; then
+    echo "RESULT: FIXED - GSO super-packet ClientHello now passes."
+    echo "  - single-segment hello (CONTROL-1): OK"
+    echo "  - multi-segment, offload OFF (CONTROL-2): OK"
+    echo "  - GSO super-packet, offload ON  (REPRO):  OK   <- was FAIL before the fix"
+    verdict=0
+  elif [[ $base_ok != 1 ]]; then
+    echo "RESULT: inconclusive - even the single-segment control failed (env/routing issue)."
+  else
+    echo "RESULT: NOT fixed. on=$on_cls off=$off_cls base_ok=$base_ok"
+  fi
+elif [[ "$on_cls" != OK && "$off_cls" == OK && $base_ok == 1 ]]; then
   echo "RESULT: REPRODUCED #1044/#1089."
   echo "  - single-segment hello (CONTROL-1): OK"
   echo "  - multi-segment, offload OFF (CONTROL-2): OK   <- not a PMTU/MTU problem"
@@ -107,5 +122,9 @@ else
 fi
 echo "=================================================================="
 
-if [[ $verdict == 0 ]]; then echo SCENARIO-tlsproxyprotov2 [OK] "(bug reproduced)"; else echo SCENARIO-tlsproxyprotov2 [FAILED] "(not reproduced)"; fi
+if [[ $verdict == 0 ]]; then
+  [[ "$EXPECT" == "fixed" ]] && echo SCENARIO-tlsproxyprotov2 [OK] "(fix verified)" || echo SCENARIO-tlsproxyprotov2 [OK] "(bug reproduced)"
+else
+  [[ "$EXPECT" == "fixed" ]] && echo SCENARIO-tlsproxyprotov2 [FAILED] "(fix not verified)" || echo SCENARIO-tlsproxyprotov2 [FAILED] "(not reproduced)"
+fi
 exit $verdict


### PR DESCRIPTION
## What

Bumps the loxilb-ebpf submodule to pull in the fullnat+ppv2 GSO fix (loxilb-io/loxilb-ebpf#87) and turns the `cicd/tlsproxyprotov2` reproduction scenario into a post-fix regression gate (`EXPECT=fixed` mode).

## Problem

With `--mode=fullnat --ppv2en`, `dp_ins_ppv2()` inserts the 28-byte PROXY v2 header into the first TCP data packet (the TLS ClientHello) via `bpf_skb_adjust_room(BPF_ADJ_ROOM_NET)`. When that packet is a GRO/GSO super-packet (`gso_size > 0`), segmentation treats the inserted bytes as replicated header space instead of TCP payload: the backend sees a 28-byte sequence hole at the start of the stream and waits forever → nginx logs `broken header: "" while reading PROXY protocol`, and the TLS 1.3 handshake dies right after ClientHello.

This is the root cause of:
- #1044 — TLSv1.3 handshake fails when proxy_protocol is enabled
- #1089 — `SSL_ERROR_SYSCALL` immediately after Client Hello
- the Windows-client failures reported in #675 — Windows first-flight patterns commonly get GRO-merged into a GSO super-packet at loxilb's NIC, while Linux/macOS hellos usually arrive as a single non-GSO segment (the same Windows machine working via WSL matches this analysis)

## Fix (in loxilb-ebpf, already merged via loxilb-io/loxilb-ebpf#87)

eBPF cannot de-GSO an skb nor mark inserted bytes as payload, so the insertion is moved off the data packet entirely:

- Insert the PPv2 header **early, on the handshake ACK** driving the SA→PEST conntrack transition — an empty ACK is never a GSO super-packet, so the proven single-segment insertion path always applies. The first data packet then only needs the GSO-safe seq fixup (+28).
- Keep the old PEST first-data trigger as a backstop, now gated on `!is_gso`: a GSO trigger packet (rare piggyback case) is dropped **without marking the connection**, so the retransmit (a single non-GSO MSS segment) carries the header instead.
- GSO detection reads `__sk_buff.gso_size` via its ctx offset (build UAPI headers predate the field), guarded for legacy kernels and stubbed for XDP; read outside the CT spin-lock section.

## Verification (`cicd/tlsproxyprotov2`)

| case | before | after |
|---|---|---|
| CONTROL-1: default MTU, offload ON (single-segment hello) | OK | OK |
| CONTROL-2: MTU 320, offload OFF (real multi-segment, non-GSO) | OK | OK |
| REPRO: MTU 320, offload ON (GSO super-packet ClientHello) | **FAIL** | **OK** |

- `EXPECT=fixed ./validation.sh` passes (new regression-gate mode); default mode still reproduces the bug on unpatched builds.
- Backend receives the real client IP (`$proxy_protocol_addr = 10.10.10.1`) on both GSO and non-GSO paths, across all 3 round-robin endpoints.

Fixes #1044