### PR TITLE
Stamp release version into the binary from the git tag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,9 +37,18 @@ jobs:
       
     - name: Build and run the loxilb Docker image with given tag
       if: github.event.inputs.tagName != ''
+      env:
+        TAGNAME: ${{ github.event.inputs.tagName }}
       run: |
-          docker build . --tag ghcr.io/loxilb-io/loxilb:${{ github.event.inputs.tagName }}
-          docker run -u root --cap-add SYS_ADMIN  --restart unless-stopped --privileged -dit -v /dev/log:/dev/log --name loxilb ghcr.io/loxilb-io/loxilb:${{ github.event.inputs.tagName }}
+          # .dockerignore excludes .git, so the in-container build cannot derive
+          # the release version from a tag -- pass it in. Image tags like
+          # "latest-amd64" name no release, so those stay on the placeholder.
+          version=""
+          if [[ "$TAGNAME" =~ ^v?([0-9]+(\.[0-9]+)+) ]]; then
+            version="${BASH_REMATCH[1]}"
+          fi
+          docker build . --build-arg VERSION="$version" --tag ghcr.io/loxilb-io/loxilb:${TAGNAME}
+          docker run -u root --cap-add SYS_ADMIN  --restart unless-stopped --privileged -dit -v /dev/log:/dev/log --name loxilb ghcr.io/loxilb-io/loxilb:${TAGNAME}
       
     - name: Publish the latest loxilb Docker image
       if: | 

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -32,6 +32,10 @@ env:
   IMAGE_NAME: ghcr.io/loxilb-io/loxilb
   TARGET_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tagName || 'latest' }}
   BUILD_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sourceTag != '' && github.event.inputs.sourceTag || (github.event_name == 'workflow_dispatch' && github.event.inputs.tagName != 'latest' && github.event.inputs.tagName || 'main') }}
+  # Release version stamped into the binary. .dockerignore excludes .git, so the
+  # in-container build cannot derive it from a tag and it has to be passed in.
+  # Empty for 'latest' (a rolling build of main, which has no release version).
+  RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tagName != 'latest' && github.event.inputs.tagName || '' }}
 
 jobs:
   build-check-amd64:
@@ -99,6 +103,7 @@ jobs:
         push: true
         build-args: |
           TAG=${{ env.BUILD_REF }}
+          VERSION=${{ env.RELEASE_VERSION }}
         tags: ${{ env.IMAGE_NAME }}:${{ env.TARGET_TAG }}-amd64
         cache-from: type=gha,scope=amd64
         cache-to: type=gha,mode=max,scope=amd64
@@ -133,6 +138,7 @@ jobs:
         push: true
         build-args: |
           TAG=${{ env.BUILD_REF }}
+          VERSION=${{ env.RELEASE_VERSION }}
           USE_DOCKER_BUILDX_ARM64=false
         tags: ${{ env.IMAGE_NAME }}:${{ env.TARGET_TAG }}-arm64
         cache-from: type=gha,scope=arm64

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -55,6 +55,22 @@ jobs:
       - name: Build loxilb deb package with latest
         if: github.event.inputs.tagName == ''
         run: cd build-tools/pkg/ && make major=latest && cd -      
+      - name: Verify the packaged binary reports the requested version
+        if: github.event.inputs.tagName != '' && github.event.inputs.tagName != 'latest'
+        env:
+          TAGNAME: ${{ github.event.inputs.tagName }}
+        run: |
+          # The release version lives in the git tag, not in the source tree, so
+          # this is what confirms the stamping actually happened. Run it before
+          # the qcow2 build so a mis-stamped binary fails in seconds rather than
+          # after the image build and smoke test.
+          deb_pkg="$(find build-tools/pkg -maxdepth 1 -type f -name '*.deb' | head -n 1)"
+          if [[ -z "$deb_pkg" ]]; then
+            echo "No deb package found under build-tools/pkg"
+            exit 1
+          fi
+
+          bash ./tools/ci/check-deb-version.sh "$deb_pkg" "$TAGNAME"
       - name: Build loxilb Ubuntu qcow2 image
         if: github.event_name == 'schedule' || github.event.inputs.buildVmImage == 'true'
         run: |
@@ -79,7 +95,14 @@ jobs:
             exit 1
           fi
 
-          bash ./tools/vm/smoke-test-qcow2.sh "$image_path"
+          # Empty for scheduled/latest builds: those track main and have no
+          # fixed version to assert against.
+          expected_version="${{ github.event.inputs.tagName }}"
+          if [[ "$expected_version" == "latest" ]]; then
+            expected_version=""
+          fi
+
+          bash ./tools/vm/smoke-test-qcow2.sh "$image_path" 900 "$expected_version"
       - name: Prepare release artifacts list
         run: |
           echo "RELEASE_ARTIFACTS=build-tools/pkg/*.deb" >> "$GITHUB_ENV"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TAG=main
 ARG OPENSSL_BUILD_CPUS=0
 ARG USE_DOCKER_BUILDX_ARM64=false
+# Release version stamped into the binary. .dockerignore excludes .git, so the
+# build below cannot derive it from a tag -- it has to be passed in. Left empty
+# the binary reports the dev placeholder from common/common.go.
+ARG VERSION=
 
 # Env variables
 ENV PATH="${PATH}:/usr/local/go/bin"
@@ -50,8 +54,8 @@ RUN mkdir -p /opt/loxilb && \
     /usr/local/sbin/loxicmd completion bash > /etc/bash_completion.d/loxi_completion && \
     # Install loxilb
     cd /root/loxilb-io/loxilb/ && \
-    go get . && make clean && if [ "$arch" = "arm64" ] && [ "$USE_DOCKER_BUILDX_ARM64" = "true" ] ; then DOCKER_BUILDX_ARM64=true make; \
-    else make ;fi && cp loxilb-ebpf/utils/mkllb_bpffs.sh /usr/local/sbin/mkllb_bpffs && \
+    go get . && make clean && if [ "$arch" = "arm64" ] && [ "$USE_DOCKER_BUILDX_ARM64" = "true" ] ; then DOCKER_BUILDX_ARM64=true make VERSION="$VERSION"; \
+    else make VERSION="$VERSION" ;fi && cp loxilb-ebpf/utils/mkllb_bpffs.sh /usr/local/sbin/mkllb_bpffs && \
     cp tools/k8s/mkllb-url /usr/local/sbin/mkllb-url && \
     cp loxilb-ebpf/utils/mkllb_cgroup.sh /usr/local/sbin/mkllb_cgroup && \
     cp /root/loxilb-io/loxilb/loxilb-ebpf/kernel/loxilb_dp_debug  /usr/local/sbin/loxilb_dp_debug && \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,22 @@ TAG?=latest
 ARM64_TAG?=$(TAG)-arm64
 BRANCH_NAME:=$(shell git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git branch --show-current || echo nogit)
 
+# VERSION stamps the release version into common.Version. The git tag is the
+# source of truth for it -- the source tree carries only a dev placeholder -- so
+# this defaults to the tag when building from an exact tag checkout (which is how
+# the deb/qcow2 packaging builds work) and is empty otherwise. Pass it explicitly
+# with `make VERSION=x.y.z` where no tag is reachable, as the image builds do.
+# When empty no stamp is applied and the placeholder in common/common.go shows
+# through, so a plain `go build` or a branch build still works unchanged.
+VERSION?=$(shell git describe --tags --exact-match 2>/dev/null)
+# `override` so that a leading v is stripped even when VERSION came from the
+# command line, which a plain assignment cannot do.
+override VERSION:=$(patsubst v%,%,$(VERSION))
+LDFLAGS:=-X 'github.com/loxilb-io/loxilb/common.BuildInfo=$(shell date '+%Y_%m_%d_%Hh:%Mm')-$(BRANCH_NAME)'
+ifneq ($(VERSION),)
+LDFLAGS+= -X 'github.com/loxilb-io/loxilb/common.Version=$(VERSION)'
+endif
+
 loxilbid=$(shell docker ps -f name=$(dock) | grep -w $(dock) | cut  -d " "  -f 1 | grep -iv  "CONTAINER")
 
 subsys:
@@ -15,7 +31,7 @@ subsys-clean:
 	cd loxilb-ebpf && $(MAKE) clean
 
 build: subsys
-	@go build -o ${bin} -ldflags="-X 'github.com/loxilb-io/loxilb/common.BuildInfo=${shell date '+%Y_%m_%d_%Hh:%Mm'}-$(BRANCH_NAME)'"
+	@go build -o ${bin} -ldflags="$(LDFLAGS)"
 	
 clean: subsys-clean
 	go clean
@@ -66,11 +82,14 @@ docker-rp-ebpf: docker-run docker-cp-ebpf
 	@docker stop $(dock) 2>&1 >> /dev/null || true
 	@docker rm $(dock) 2>&1 >> /dev/null || true
 
+# VERSION is forwarded into the image build because .dockerignore excludes .git,
+# so the in-container `make` cannot derive it from a tag the way the deb build
+# does. Without it the image falls back to the dev placeholder in common.go.
 docker:
-	docker build -t $(IMAGE):$(TAG) .
+	docker build -t $(IMAGE):$(TAG) --build-arg VERSION=$(VERSION) .
 
 docker-arm64:
-	docker  buildx build --platform linux/arm64 --load -t $(IMAGE):$(ARM64_TAG) .
+	docker  buildx build --platform linux/arm64 --load -t $(IMAGE):$(ARM64_TAG) --build-arg VERSION=$(VERSION) .
 
 lint:
 	golangci-lint run --enable-all

--- a/common/common.go
+++ b/common/common.go
@@ -21,9 +21,18 @@ import (
 	"time"
 )
 
-const (
-	Version = "0.9.8.6-beta"
-)
+// Version - loxilb version as reported by `loxilb --version` and the /version
+// API.
+//
+// This value is only a development placeholder and is deliberately not a
+// release number: the git tag is the source of truth for released builds, which
+// stamp it at link time via the Makefile's VERSION variable:
+//
+//	-ldflags "-X 'github.com/loxilb-io/loxilb/common.Version=<ver>'"
+//
+// That is why this is a var and not a const -- a const cannot be stamped. A
+// build reporting this placeholder is a build from source, not a release.
+var Version = "0.9.8-dev"
 
 var BuildInfo string = ""
 

--- a/tools/ci/check-deb-version.sh
+++ b/tools/ci/check-deb-version.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Verify that the loxilb binary inside a built deb reports the version that was
+# actually requested for the release.
+#
+# usage: check-deb-version.sh <deb-path> <expected-version>
+#
+# The release version is carried by the git tag and stamped into the binary at
+# build time, so nothing in the source tree records it. That makes this check
+# the thing that decides whether the packaging pipeline did its job: it opens
+# the artifact that is about to be published and asks the binary itself.
+#
+# An expected version of "latest"/"" is a rolling build with no fixed version
+# and is skipped.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <deb-path> <expected-version>" >&2
+  exit 1
+fi
+
+deb_path="$1"
+expected="$2"
+
+expected="${expected#refs/tags/}"
+expected="${expected#v}"
+
+if [[ -z "$expected" || "$expected" == "latest" ]]; then
+  echo "check-deb-version: rolling build, nothing to verify"
+  exit 0
+fi
+
+if [[ ! -f "$deb_path" ]]; then
+  echo "check-deb-version: deb package not found: $deb_path" >&2
+  exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+dpkg-deb -x "$deb_path" "$workdir"
+
+binary="$workdir/usr/local/sbin/loxilb"
+if [[ ! -x "$binary" ]]; then
+  echo "check-deb-version: no loxilb binary at usr/local/sbin/loxilb inside $deb_path" >&2
+  exit 1
+fi
+
+# `loxilb --version` prints a "loxilb start" banner before the version line, so
+# select the line rather than taking the first one.
+if ! version_out="$("$binary" --version 2>&1)"; then
+  echo "check-deb-version: could not run the packaged binary" >&2
+  printf '%s\n' "$version_out" >&2
+  exit 1
+fi
+
+reported="$(printf '%s\n' "$version_out" | awk '/^loxilb version:/ {print $3; exit}')"
+
+if [[ -z "$reported" ]]; then
+  echo "check-deb-version: could not parse a version out of:" >&2
+  printf '%s\n' "$version_out" >&2
+  exit 1
+fi
+
+# The tag carries no pre-release suffix while a dev fallback build does, so
+# 0.9.8.8 is satisfied by either 0.9.8.8 or 0.9.8.8-<suffix>, but not by
+# 0.9.8.85 and not by the in-source dev placeholder.
+if [[ "$reported" == "$expected" || "$reported" == "$expected"-* ]]; then
+  echo "check-deb-version: OK -- $(basename "$deb_path") reports '$reported'"
+  exit 0
+fi
+
+cat >&2 <<EOF
+check-deb-version: VERSION MISMATCH
+  requested release : $expected
+  binary reports    : $reported
+  package           : $deb_path
+
+The build did not stamp the release version into the binary. The packaging
+build must compile from an exact tag checkout, or pass it explicitly with
+'make VERSION=$expected'. Publishing this artifact would ship a binary that
+misreports its own version.
+EOF
+exit 1

--- a/tools/vm/smoke-test-qcow2.sh
+++ b/tools/vm/smoke-test-qcow2.sh
@@ -3,12 +3,21 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "usage: $0 <qcow2-path> [timeout-seconds]" >&2
+  echo "usage: $0 <qcow2-path> [timeout-seconds] [expected-version]" >&2
   exit 1
 fi
 
 image_path="$1"
 timeout_seconds="${2:-900}"
+# When given, the booted image must report this version from `loxilb --version`.
+# This is the end-to-end assertion that the packaged binary is not stamped with
+# a stale common.Version. Leave empty for rolling/latest builds.
+expected_version="${3:-}"
+expected_version="${expected_version#refs/tags/}"
+expected_version="${expected_version#v}"
+if [[ "$expected_version" == "latest" ]]; then
+  expected_version=""
+fi
 
 if [[ ! -f "$image_path" ]]; then
   echo "qcow2 image not found: $image_path" >&2
@@ -40,8 +49,25 @@ output:
   all: '| tee -a /var/log/cloud-init-output.log /dev/ttyS0'
 runcmd:
   - |
+    expected_version="@EXPECTED_VERSION@"
     for _ in $(seq 1 24); do
       if systemctl is-active --quiet loxilb; then
+        cat /etc/loxilb-release 2>/dev/null || true
+        # `loxilb --version` emits a "loxilb start" banner before the version
+        # line, so select the line rather than taking the first one.
+        version_out="$(/usr/local/sbin/loxilb --version 2>/dev/null)"
+        reported="$(printf '%s\n' "$version_out" | awk '/^loxilb version:/ {print $3; exit}')"
+        echo "LOXILB_VERSION_REPORTED: ${reported}"
+        if [ -n "$expected_version" ]; then
+          case "$reported" in
+            "$expected_version"|"$expected_version"-*) ;;
+            *)
+              echo "LOXILB_SMOKETEST_FAIL_VERSION expected=${expected_version} reported=${reported}"
+              poweroff
+              exit 1
+              ;;
+          esac
+        fi
         echo LOXILB_SMOKETEST_PASS
         poweroff
         exit 0
@@ -53,6 +79,10 @@ runcmd:
     poweroff
     exit 1
 EOF
+
+# The heredoc above is quoted so the guest script survives verbatim; the one
+# host-side value it needs is substituted here.
+sed -i "s|@EXPECTED_VERSION@|${expected_version}|" "$workdir/user-data"
 
 cat > "$workdir/meta-data" <<'EOF'
 instance-id: loxilb-smoketest
@@ -89,9 +119,18 @@ if [[ $qemu_rc -ne 0 ]]; then
   exit 1
 fi
 
+if grep -q 'LOXILB_SMOKETEST_FAIL_VERSION' "$console_log"; then
+  echo "Packaged loxilb reports the wrong version (expected $expected_version) -- see LOXILB_SMOKETEST_FAIL_VERSION above" >&2
+  exit 1
+fi
+
 if ! grep -q 'LOXILB_SMOKETEST_PASS' "$console_log"; then
   echo "Did not observe LOXILB_SMOKETEST_PASS in console output" >&2
   exit 1
 fi
 
-echo "qcow2 smoke test passed"
+if [[ -n "$expected_version" ]]; then
+  echo "qcow2 smoke test passed (version $expected_version verified)"
+else
+  echo "qcow2 smoke test passed (no expected version given, version check skipped)"
+fi


### PR DESCRIPTION
The deb and qcow2 packages for v0.9.8.7 shipped a binary reporting 0.9.8.6-beta. common.Version was a const, so -ldflags -X could not override it, and the value was only ever updated by hand.

Make the git tag the source of truth:
  - common.Version becomes a var holding a dev placeholder; release builds stamp it via the Makefile's VERSION variable
  - VERSION defaults to an exact tag checkout, which is how the deb packaging builds, and can be passed explicitly otherwise
  - .dockerignore excludes .git, so the image builds take VERSION as a build arg instead

Add two checks so a mis-stamped artifact cannot be published: the packaging workflow inspects the built deb, and the qcow2 smoke test compares `loxilb --version` in the booted image against the tag.