### PR TITLE
Check release tags before building, and only gate release publishes

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -26,6 +26,22 @@ on:
         default: false
         type: boolean
 
+# True only for a run that publishes a versioned GitHub release -- the one case
+# where a mis-stamped or mis-built artifact reaches users, and so the only case
+# where the version checks below should be able to fail a build.
+#
+# Deliberately excluded:
+#   - scheduled runs, which publish to vlatest; that tracks main and has no
+#     fixed version to verify against (tagName is empty on a schedule event).
+#   - manual runs with publishRelease=false, which only attach artifacts to the
+#     workflow run. Those must stay buildable for any tag, including old ones
+#     whose trees predate version stamping and would legitimately fail a check.
+env:
+  VERSIONED_RELEASE: ${{ github.repository == 'loxilb-io/loxilb'
+    && github.event.inputs.publishRelease == 'true'
+    && github.event.inputs.tagName != ''
+    && github.event.inputs.tagName != 'latest' }}
+
 jobs:
   build:
     name: Build OS packages
@@ -47,6 +63,15 @@ jobs:
         run: | 
              sudo mkdir -p /opt/loxilb/
              sudo apt-get purge -y libssl-dev 2>&1 >> /dev/null  | true
+      - name: Verify the release tags are consistent
+        if: env.VERSIONED_RELEASE == 'true'
+        env:
+          TAGNAME: ${{ github.event.inputs.tagName }}
+        run: |
+          # Runs before anything expensive: the packaging build spends a long
+          # time on an openssl source build before it ever reaches the git
+          # checkouts that would notice a missing tag.
+          bash ./tools/ci/check-release-tags.sh "$TAGNAME"
       - name: Clone packaging tools
         run: git clone https://github.com/loxilb-io/tools.git build-tools
       - name: Build loxilb deb package with given tag
@@ -56,7 +81,7 @@ jobs:
         if: github.event.inputs.tagName == ''
         run: cd build-tools/pkg/ && make major=latest && cd -      
       - name: Verify the packaged binary reports the requested version
-        if: github.event.inputs.tagName != '' && github.event.inputs.tagName != 'latest'
+        if: env.VERSIONED_RELEASE == 'true'
         env:
           TAGNAME: ${{ github.event.inputs.tagName }}
         run: |
@@ -95,11 +120,13 @@ jobs:
             exit 1
           fi
 
-          # Empty for scheduled/latest builds: those track main and have no
-          # fixed version to assert against.
-          expected_version="${{ github.event.inputs.tagName }}"
-          if [[ "$expected_version" == "latest" ]]; then
-            expected_version=""
+          # Only assert the version when this run publishes a versioned release.
+          # Otherwise leave it empty: the smoke test still boots the image and
+          # still prints LOXILB_VERSION_REPORTED, it just does not fail the run
+          # over a version, so artifact-only builds of any tag stay possible.
+          expected_version=""
+          if [[ "$VERSIONED_RELEASE" == "true" ]]; then
+            expected_version="${{ github.event.inputs.tagName }}"
           fi
 
           bash ./tools/vm/smoke-test-qcow2.sh "$image_path" 900 "$expected_version"

--- a/tools/ci/check-release-tags.sh
+++ b/tools/ci/check-release-tags.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Verify a release tag is usable by the packaging build, before that build
+# spends time on anything.
+#
+# usage: check-release-tags.sh <tag>
+#
+# pkg/debian/make.sh in loxilb-io/tools checks out the *same tag name* in three
+# repos -- loxilb, loxilb-ebpf and loxicmd -- and it ignores the submodule
+# pointer recorded in the loxilb tag, checking out the ebpf tag instead. Two
+# things therefore have to hold:
+#
+#   A. All three repos carry the tag. A missing one does abort make.sh under
+#      set -e, but only after the openssl source build, and with a raw git
+#      pathspec error rather than a message naming the repo at fault.
+#
+#   B. The ebpf tag names the same commit the loxilb tag pins as its submodule.
+#      If it does not, the release ships eBPF code other than what the loxilb
+#      tag was built and tested against, and nothing anywhere reports it.
+#
+# A tag of "latest"/"" is a rolling build with no fixed version and is skipped.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <tag>" >&2
+  exit 1
+fi
+
+raw_tag="$1"
+tag="${raw_tag#refs/tags/}"
+tag="${tag#v}"
+
+if [[ -z "$tag" || "$tag" == "latest" ]]; then
+  echo "check-release-tags: rolling build (tag='$raw_tag'), nothing to verify"
+  exit 0
+fi
+
+tag="v${tag}"
+repos=(loxilb loxilb-ebpf loxicmd)
+
+# Resolve a remote tag to the commit it names. Annotated tags need the peeled
+# ref, lightweight tags only have the plain one, so ask for both and prefer the
+# peeled value.
+peel_remote_tag() {
+  local url="$1" ref="refs/tags/$2"
+  git ls-remote "$url" "$ref" "$ref^{}" 2>/dev/null |
+    awk -v peeled="$ref^{}" -v plain="$ref" '
+      $2 == peeled { p = $1 }
+      $2 == plain  { l = $1 }
+      END { print (p != "" ? p : l) }'
+}
+
+# --- A. the tag exists in all three repos ------------------------------------
+missing=()
+declare -A tag_commit=()
+for repo in "${repos[@]}"; do
+  commit="$(peel_remote_tag "https://github.com/loxilb-io/${repo}.git" "$tag")"
+  if [[ -z "$commit" ]]; then
+    missing+=("$repo")
+    echo "check-release-tags: $repo has NO tag $tag"
+  else
+    tag_commit["$repo"]="$commit"
+    echo "check-release-tags: $repo $tag -> ${commit:0:12}"
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  cat >&2 <<EOF
+
+check-release-tags: MISSING TAG in ${missing[*]}
+
+The packaging build checks out $tag in loxilb, loxilb-ebpf and loxicmd alike,
+so it would abort part-way through. Create $tag in the repos above -- in
+loxilb-ebpf it must name the commit the loxilb tag pins as its submodule --
+and re-run.
+EOF
+  exit 1
+fi
+
+# --- B. the ebpf tag matches the submodule pointer ---------------------------
+if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1; then
+  git fetch --depth 1 origin "refs/tags/$tag:refs/tags/$tag" >/dev/null 2>&1 || true
+fi
+
+if ! pinned="$(git ls-tree "$tag" loxilb-ebpf 2>/dev/null | awk '{print $3}')" || [[ -z "$pinned" ]]; then
+  echo "check-release-tags: could not read the loxilb-ebpf submodule pointer at $tag" >&2
+  exit 1
+fi
+
+built="${tag_commit[loxilb-ebpf]}"
+if [[ "$pinned" == "$built" ]]; then
+  echo "check-release-tags: OK -- loxilb-ebpf $tag matches the submodule pointer (${pinned:0:12})"
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+check-release-tags: SUBMODULE POINTER MISMATCH
+  loxilb $tag pins loxilb-ebpf : $pinned
+  loxilb-ebpf tag $tag names   : $built
+
+The packaging build checks out the ebpf tag, not the submodule pointer, so this
+release would ship eBPF code other than what $tag was built against. Move the
+loxilb-ebpf tag onto $pinned, or bump the submodule and re-cut $tag.
+EOF
+exit 1


### PR DESCRIPTION
Two changes to `package.yaml`: a new preflight, and a narrower scope
for the version checks added in #1100.

## Preflight

`pkg/debian/make.sh` checks out the *same tag name* in loxilb, loxilb-ebpf
and loxicmd, and it ignores the submodule pointer recorded in the loxilb
tag -- it checks out the ebpf tag instead. Nothing verified either fact.

**A. The tag exists in all three repos.** A missing one does abort the
build under `set -e`, but only after the openssl source build, and with a
raw `pathspec did not match` error rather than a message naming the repo
at fault. Both loxilb-ebpf and loxicmd are missing `v0.9.8.5` and
`v0.9.8.6` today.

**B. The ebpf tag names the commit the loxilb tag pins.** If it does not,
the release ships eBPF code other than what the tag was built against, and
nothing anywhere reports it. Every tag from v0.9.8 to v0.9.8.7 happens to
be consistent, so this one is preventive rather than a fix -- but it is
the silent failure of the two, and #1101 was a reminder of how easily the
pointer and the branch it came from can drift apart.

No credentials needed: the repos are public, so `git ls-remote` suffices.

## Narrower scope for the version checks

The deb check from #1100 fired on any run naming a tag. That would block
the artifact-only path -- `workflow_dispatch` with `publishRelease=false`,
which attaches artifacts to the run without touching a release. Building
an older tag that way would fail every time, since those trees predate
version stamping and legitimately report a different version.

The checks exist to stop a bad artifact reaching users, so they now key
off a single `VERSIONED_RELEASE` expression mirroring the publish steps:

| run | VERSIONED_RELEASE |
|---|---|
| schedule (publishes vlatest, no fixed version) | false |
| dispatch, `latest` | false |
| dispatch, `0.9.8.8`, `publishRelease=false` | false |
| dispatch, `0.9.8.8`, `publishRelease=true` | **true** |
| fork | false |

The qcow2 smoke test still boots the image and still prints
`LOXILB_VERSION_REPORTED` in every case; it just stops failing the run
over a version unless the run publishes one.

## Verification

`check-release-tags.sh` was run against the real remotes:

- `0.9.8.7` -- passes; all three tags present, ebpf tag matches the pin
- `v0.9.8.6` -- fails, naming loxilb-ebpf and loxicmd as missing
- `latest` -- skips
- pointer mismatch -- exercised through the real code path with an
  injected SHA; fails with both commits reported

Tag resolution handles annotated and lightweight tags alike by preferring
the peeled ref.