### PR TITLE
cicd: check wRR distribution instead of exact response order

### DIFF
--- a/cicd/wrrtcplb1/validation.sh
+++ b/cicd/wrrtcplb1/validation.sh
@@ -33,29 +33,77 @@ do
     sleep 1
 done
 
-respArr=( "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server2" "server2"
-          "server2" "server2" "server2"
-          "server2" "server1" )
+# Endpoint weights as configured in config.sh. server3 is deliberately not an
+# endpoint of this rule, so it must receive nothing.
+weightArr=( 80 20 0 )
+nreq=32
+tol=3
+cntArr=( 0 0 0 )
+noResp=0
 
-for i in {0..31}
+# What wRR guarantees is the share of traffic each endpoint gets, not the order
+# the endpoints come back in. The order is an artifact of how weights are
+# expanded into datapath slots: with a 32 slot table the 20% endpoint answered
+# as one run of 6, with the 16 slot table used since the LLB_NAT_STAT_CID fix it
+# answers as two runs of 3. Same share, different sequence. Asserting the exact
+# sequence made this test fail on a change that did not alter the balancing at
+# all, so check the distribution instead.
+for i in $(seq 0 $(( nreq - 1 )))
 do
     res=$($hexec l3h1 curl --max-time 10 -s 20.20.20.1:2020)
     echo $i:$res
-    if [[ $res != "${respArr[i]}" ]]
+    matched=0
+    for k in 0 1 2
+    do
+        if [[ $res == "${servArr[k]}" ]]
+        then
+            cntArr[k]=$(( ${cntArr[k]} + 1 ))
+            matched=1
+            break
+        fi
+    done
+    if [[ $matched == 0 ]]
     then
-        echo "expected ${respArr[i]} rcvd $res"
-        code=1
+        noResp=$(( noResp + 1 ))
     fi
     sleep 1
 done
+
+echo "--- distribution over $nreq requests (tolerance +/-$tol) ---"
+for k in 0 1 2
+do
+    got=${cntArr[k]}
+    if [[ ${weightArr[k]} == 0 ]]
+    then
+        if [[ $got != 0 ]]
+        then
+            echo "${servArr[k]}: $got, expected 0 (not an endpoint of this rule) [FAILED]"
+            code=1
+        else
+            echo "${servArr[k]}: $got, not an endpoint of this rule [OK]"
+        fi
+        continue
+    fi
+    # rounded ideal share for this weight
+    want=$(( (nreq * ${weightArr[k]} + 50) / 100 ))
+    diff=$(( got - want ))
+    if [[ $diff -lt 0 ]]
+    then
+        diff=$(( 0 - diff ))
+    fi
+    if [[ $diff -gt $tol ]]
+    then
+        echo "${servArr[k]}: $got, weight ${weightArr[k]}% expects ~$want [FAILED]"
+        code=1
+    else
+        echo "${servArr[k]}: $got, weight ${weightArr[k]}% expects ~$want [OK]"
+    fi
+done
+if [[ $noResp != 0 ]]
+then
+    echo "$noResp request(s) returned no valid server response [FAILED]"
+    code=1
+fi
 sudo killall -9 node 2>&1 > /dev/null
 if [[ $code == 0 ]]
 then

--- a/cicd/wrrtcplb2/validation.sh
+++ b/cicd/wrrtcplb2/validation.sh
@@ -33,30 +33,64 @@ do
     sleep 1
 done
 
-respArr=( "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server1" "server1" "server1"
-          "server2" "server2" "server2"
-          "server2" "server2" "server2"
-          "server2" "server2" "server2"
-          "server2" "server2" "server2"
-          "server3" "server3" "server3"
-          "server3" "server3" "server3"
-          "server1" "server1"
-         )
+# Endpoint weights as configured in config.sh.
+weightArr=( 40 40 20 )
+nreq=32
+tol=3
+cntArr=( 0 0 0 )
+noResp=0
 
-for i in {0..31}
+# What wRR guarantees is the share of traffic each endpoint gets, not the order
+# the endpoints come back in. The order is an artifact of how weights are
+# expanded into datapath slots, and it changed when that table went from 32 to
+# 16 slots for the LLB_NAT_STAT_CID fix, without the shares changing at all.
+# Asserting the exact sequence made this test fail on a change that did not
+# alter the balancing, so check the distribution instead.
+for i in $(seq 0 $(( nreq - 1 )))
 do
     res=$($hexec l3h1 curl --max-time 10 -s 20.20.20.1:2020)
     echo $i:$res
-    if [[ $res != "${respArr[i]}" ]]
+    matched=0
+    for k in 0 1 2
+    do
+        if [[ $res == "${servArr[k]}" ]]
+        then
+            cntArr[k]=$(( ${cntArr[k]} + 1 ))
+            matched=1
+            break
+        fi
+    done
+    if [[ $matched == 0 ]]
     then
-        echo "expected ${respArr[i]} rcvd $res"
-        code=1
+        noResp=$(( noResp + 1 ))
     fi
     sleep 1
 done
+
+echo "--- distribution over $nreq requests (tolerance +/-$tol) ---"
+for k in 0 1 2
+do
+    got=${cntArr[k]}
+    # rounded ideal share for this weight
+    want=$(( (nreq * ${weightArr[k]} + 50) / 100 ))
+    diff=$(( got - want ))
+    if [[ $diff -lt 0 ]]
+    then
+        diff=$(( 0 - diff ))
+    fi
+    if [[ $diff -gt $tol ]]
+    then
+        echo "${servArr[k]}: $got, weight ${weightArr[k]}% expects ~$want [FAILED]"
+        code=1
+    else
+        echo "${servArr[k]}: $got, weight ${weightArr[k]}% expects ~$want [OK]"
+    fi
+done
+if [[ $noResp != 0 ]]
+then
+    echo "$noResp request(s) returned no valid server response [FAILED]"
+    code=1
+fi
 sudo killall -9 node 2>&1 > /dev/null
 if [[ $code == 0 ]]
 then


### PR DESCRIPTION
`cicd/wrrtcplb1` has failed on every run of Adv-LB-Sanity-CI since
2026-07-23, on main as well as on PR branches. It is a stale test
expectation, not a functional regression.

## Root cause

Last green on main was `6053e28f` (07-21), first red was `bf318133`
(07-23). One commit sits between them:

    cbf319c3  fix wRR health marking and per-endpoint LB stats; bump loxilb-ebpf

It shrank the wRR slot table from 32 to 16 entries:

```diff
-var neps [MaxLBEndPoints]ruleLBEp
+var neps [MaxLBPrioSlots]ruleLBEp
-sw := (int(ep.weight) * MaxLBEndPoints) / 100
+sw := (int(ep.weight) * MaxLBPrioSlots) / 100
```

for a good reason -- the stat counter id carries only 4 bits of arm id
(`nStat.Mark = ... | (uint32(s) & 0xf)`), so slots past 16 aliased their
stats onto slots 0-15 and corrupted per-endpoint counters.

That halves the cycle length, which changes the order endpoints answer
in but not the share they receive. With 80/20 over 32 requests:

| slots | per cycle | over 32 requests | totals |
|---|---|---|---|
| 32 (old) | 25 x s1, 6 x s2, 1 filler | one cycle | 26 / 6 |
| 16 (now) | 12 x s1, 3 x s2, 1 filler | two cycles | 26 / 6 |

The totals are identical and match the configured weights. Only the
interleaving differs -- the 20% endpoint used to answer as one run of 6
and now answers as two runs of 3, which is if anything smoother. The
test hardcoded a 32 entry sequence copied from the old slot layout, so
it broke on a change that did not affect balancing.

## Change

Count what each endpoint served over the run and compare against its
configured weight with a tolerance, instead of asserting the sequence.

`wrrtcplb2` gets the same treatment. Its totals (14/12/6) are unaffected
by the slot change too, but its hardcoded sequence would break for the
same reason -- it is only passing today because wrrtcplb1 fails first and
skips it.

## Verification

The verdict logic was exercised against real and synthetic sequences:

| case | result |
|---|---|
| observed CI sequence, 16 slots (26/6) | pass |
| legacy sequence, 32 slots (26/6) | pass |
| all traffic to one endpoint (32/0) | **fail** |
| weights ignored, even split (16/16) | **fail** |
| traffic to server3, not an endpoint of wrrtcplb1 | **fail** |
| requests returning no response | **fail** |
| wrrtcplb2 expected (14/12/6) | pass |
| wrrtcplb2 with server3 starved | **fail** |

Both layouts pass, so the test no longer couples to `MaxLBPrioSlots`, and
every meaningful regression is still caught.