### PR TITLE
ci: add the GHCR retention workflow

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -1,0 +1,86 @@
+name: GHCR-Retention
+
+# GitHub applies no retention to container packages, so every rebuild of a
+# rolling tag leaves its predecessor behind as an untagged version that stays
+# forever. Left alone since 2024 that grew to 699 untagged versions against 71
+# tagged ones.
+#
+# The pruning is deliberately not one of the off-the-shelf "delete untagged"
+# actions: a multi-arch tag is an index whose per-platform children are
+# themselves untagged versions, so deleting by tag-emptiness alone destroys
+# images that are still tagged and still in use. tools/ci/ghcr-prune.py walks
+# the reference graph from every tag first and only removes what nothing tagged
+# can reach. (ghcr.io/loxilb-io/loxilb:v0.9.4 lost its linux/amd64 manifest to
+# exactly this mistake and cannot be pulled on amd64 today.)
+#
+# Scope is this repository's own package and nothing else. GITHUB_TOKEN can
+# only delete versions of packages linked to the repository it came from, and
+# loxilb is the one linked here; kube-loxilb, loxilb-ingress, loxi-ccm and the
+# rest belong to their own repositories. Those want a copy of this workflow in
+# the repository that owns them, not a cross-repository token here.
+
+on:
+  schedule:
+    # Weekly is enough for a 90-day window and keeps the run log readable.
+    - cron: '30 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      olderThanDays:
+        description: 'Only delete orphans last updated at least this many days ago'
+        required: true
+        default: '90'
+      apply:
+        description: 'Actually delete. Leave off for a dry run that only reports.'
+        required: true
+        default: false
+        type: boolean
+
+jobs:
+  prune:
+    name: Prune orphaned container versions
+    # A fork has no package of its own to prune, and its GITHUB_TOKEN cannot
+    # touch the upstream org's.
+    if: github.repository == 'loxilb-io/loxilb'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prune
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A scheduled run deletes; that is the point of a retention policy,
+          # and the script refuses to act on an incomplete reference graph. A
+          # manual run defaults to a dry run so the listing can be reviewed.
+          APPLY: ${{ github.event_name == 'schedule' && 'true' || inputs.apply }}
+          OLDER_THAN: ${{ inputs.olderThanDays || '90' }}
+        run: |
+          # -e and pipefail together are what make a failed prune fail the step.
+          # pipefail alone is not enough: the closing fence echoed after the
+          # pipeline would become the step's exit status and paper over it.
+          # GitHub's default shell already supplies -e, but this does not rely
+          # on that.
+          set -e -u -o pipefail
+          mkdir -p prune-records
+          args=(--owner loxilb-io --package loxilb --older-than-days "$OLDER_THAN"
+                --record prune-records/loxilb.json)
+          if [[ "$APPLY" == "true" ]]; then
+            args+=(--apply)
+          fi
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          python3 tools/ci/ghcr-prune.py "${args[@]}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      # A deleted version is restorable for 30 days, but only by id, and the ids
+      # are unlistable once the versions are gone. The record is the only way
+      # back, so it outlives the run by the length of that window.
+      - name: Upload the deletion record
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prune-record
+          path: prune-records/loxilb.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/tools/ci/ghcr-prune.py
+++ b/tools/ci/ghcr-prune.py
@@ -156,6 +156,13 @@ def main():
         default=0,
         help="stop after this many deletions (0 = no limit)",
     )
+    ap.add_argument(
+        "--record",
+        metavar="FILE",
+        help="write the id/digest of every candidate to FILE as JSON. GitHub "
+        "keeps a deleted version restorable for 30 days, but only by id, so "
+        "without this the ids are gone with them.",
+    )
     args = ap.parse_args()
 
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
@@ -166,9 +173,19 @@ def main():
     quoted = urllib.parse.quote(package, safe="")
 
     print(f"package: {REGISTRY}/{owner}/{package}")
-    versions = api_paged(
-        f"/orgs/{owner}/packages/container/{quoted}/versions?per_page=100", token
-    )
+    try:
+        versions = api_paged(
+            f"/orgs/{owner}/packages/container/{quoted}/versions?per_page=100", token
+        )
+    except urllib.error.HTTPError as exc:
+        # Worth naming rather than letting a traceback out: callers loop over a
+        # list of packages, so a typo or a package the token cannot see should
+        # read as one clear line among the others.
+        hint = {
+            403: "token lacks read:packages, or cannot see this package",
+            404: "no such container package under this owner",
+        }.get(exc.code, "")
+        raise Fatal(f"cannot list versions of {owner}/{package}: {exc}. {hint}")
     tagged = {
         v["name"]: v["metadata"]["container"]["tags"]
         for v in versions
@@ -214,6 +231,28 @@ def main():
         return 0
 
     print(f"\n  oldest: {orphans[0]['updated_at']}   newest: {orphans[-1]['updated_at']}")
+
+    if args.record:
+        with open(args.record, "w") as fh:
+            json.dump(
+                {
+                    "owner": owner,
+                    "package": package,
+                    "older_than_days": args.older_than_days,
+                    "applied": bool(args.apply),
+                    "versions": [
+                        {
+                            "id": v["id"],
+                            "digest": v["name"],
+                            "updated_at": v["updated_at"],
+                        }
+                        for v in orphans
+                    ],
+                },
+                fh,
+                indent=1,
+            )
+        print(f"  recorded {len(orphans)} candidates to {args.record}")
 
     if not args.apply:
         print("\nDRY RUN -- pass --apply to delete")


### PR DESCRIPTION
Follow-up to #1108. That PR stopped new junk being created and added `tools/ci/ghcr-prune.py`, but nothing runs it. This schedules it.

## Why it still matters

Every rebuild of a rolling tag leaves its predecessor behind untagged, and GitHub reaps none of it. On this package that reached **699 untagged versions against 71 tagged ones** before it was cleaned out by hand. Hand-cleaning does not hold; this does.

## Scope: this repository's package only

`GITHUB_TOKEN` can only delete versions of packages linked to the repository it came from, and **`loxilb` is the one linked here.** `kube-loxilb`, `loxilb-ingress`, `loxi-ccm` and the rest belong to their own repositories.

Those are deliberately out of scope. They want a copy of this workflow in the repository that owns them, rather than a cross-repository PAT sitting in this one — so **there is no secret to create and nothing to configure after merge.**

> Note for whoever copies this into another repo: the `kube-loxilb-operator`, `-bundle` and `-index` packages need care. OLM images reference each other **by digest across packages** (a catalog index names bundle images, a bundle CSV names the operator image), and `ghcr-prune.py` only walks references *within* one package. An untagged bundle version can be live and still look orphaned to it.

## Restore safety

`--record` (new) writes the id and digest of every candidate. GitHub keeps a deleted version restorable for 30 days **but only by id**, and the ids become unlistable once the versions are gone — so without this there is no way back. The workflow uploads the record as an artifact with a matching 30-day retention, including on failure.

## Verification

The `run:` block was extracted from the workflow and executed **verbatim**, from the repo root, against the real package:

- **happy path** — exit 0, 111 candidates identified, record artifact written
- **failure path** (invalid token) — exit **2**, failure correctly propagated

That second test caught a real defect. `pipefail` alone did **not** fail the step: the closing code fence echoed after the pipeline became the step's exit status and papered over a failed prune. Fixed by setting `-e` explicitly rather than relying on GitHub's default shell supplying it.

## Note on defaults

A **scheduled** run deletes — that is the point of a retention policy, and the script fails closed if it cannot resolve the full reference graph. A **manual** run defaults to a dry run so the listing can be reviewed first.