### PR TITLE
cicd/sconnect: restore the pipe into cut when listing L2 hosts

### DIFF
--- a/cicd/sconnect/validation.sh
+++ b/cicd/sconnect/validation.sh
@@ -34,7 +34,7 @@ for ns1 in "${nslist[@]}"; do
     then
         # No default route present, will try L2 now
         net1=( `sudo ip netns exec $ns1 ip route | grep -v "eth0" | cut -d " " -f 1` )
-	    allhosts1=( `sudo ip netns exec $ns1 ip route | grep -v "eth0" cut -d " " -f 9` )
+	    allhosts1=( `sudo ip netns exec $ns1 ip route | grep -v "eth0" | cut -d " " -f 9` )
         ns1L2=1
         echo -e "$ns1 can do only L2"
     else


### PR DESCRIPTION
## The symptom

Sanity-CI-Ubuntu-24 prints a grep usage error in the middle of the sconnect run:

```
grep: invalid argument ‘ ’ for ‘--directories’
Valid arguments are:
  - ‘read’
  - ‘recurse’
  - ‘skip’
llb1 can do only L2
```

## The cause

[`cicd/sconnect/validation.sh:37`](cicd/sconnect/validation.sh#L37) is missing a pipe:

```bash
allhosts1=( `sudo ip netns exec $ns1 ip route | grep -v "eth0" cut -d " " -f 9` )
                                                             ^ no |
```

So grep receives `cut` as a **filename** and cut's flags as its own:

| token | how grep reads it |
|---|---|
| `-v "eth0"` | invert-match on pattern `eth0` |
| `cut` | input file |
| `-d " "` | `--directories=" "` → **invalid**, must be read/recurse/skip |
| `-f 9` | `--file=9` (read patterns from file `9`) |

grep exits 2 with the usage message. The line immediately after is `echo -e "$ns1 can do only L2"`, which is exactly where the message lands in the log.

## Where it came from

e0ab8926 (2022-11-30, "Clustering support added") inserted `grep -v "eth0"` into an existing pipeline and dropped the pipe:

```diff
- allhosts1=( `sudo ip netns exec $ns1 ip route | cut -d " " -f 9` )
+ allhosts1=( `sudo ip netns exec $ns1 ip route | grep -v "eth0" cut -d " " -f 9` )
```

It has been emitting this on every affected run for over three years.

## Impact: log noise only

`allhosts1` is assigned here only when `$ns1` has no default route, which also sets `ns1L2=1`. The ns2 loop below re-derives `net1` and `allhosts1` whenever `ns1L2` is 1 (line 81-87, with the pipes intact), so **the empty array this produced was always overwritten before `hosts1` consumed it at line 103.**

No test result changes. What this fixes is the stderr noise, and a dead assignment that would have started mattering the moment anyone reordered those blocks.

## Verification

Reproduced against synthetic `ip route` output:

```
BROKEN: exit=2, allhosts=(), count=0        <- plus the usage message
FIXED : exit=0, allhosts=(31.31.31.1 32.32.32.1), count=2
```

`bash -n` passes. Swept the whole `cicd/` tree for the same `grep … <cmd>` shape with a dropped pipe — this was the only occurrence.