### PR TITLE
ci: rebuild the image when only the ebpf submodule moves

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -14,6 +14,12 @@ on:
       - 'common/**'
       - 'options/**'
       - 'pkg/**'
+      # Both forms are needed. A submodule bump changes the gitlink, whose path
+      # is the bare 'loxilb-ebpf' -- 'loxilb-ebpf/**' requires a 'loxilb-ebpf/'
+      # prefix and never matches it, so a datapath-only bump used to skip the
+      # image build entirely. The '/**' form stays for the day the submodule is
+      # vendored in-tree.
+      - 'loxilb-ebpf'
       - 'loxilb-ebpf/**'
       - 'tools/**'
       - '.github/workflows/docker-multiarch.yml'


### PR DESCRIPTION
## Problem

`Docker-Multi-Arch` filters pushes on `paths:`, and the list carried only
`'loxilb-ebpf/**'`. A submodule bump does not change anything *under* that
directory — it changes the gitlink, whose path is the bare `loxilb-ebpf`:

```
$ git diff --name-only ec417cd3^ ec417cd3
loxilb-ebpf
```

`'loxilb-ebpf/**'` requires a `loxilb-ebpf/` prefix, so it never matched. A push
whose only build-relevant change is in the datapath skipped the image build, and
`:latest` kept serving the previous datapath.

## It already bit us

The #1111 merge touched `loxilb-ebpf`, three files under `cicd/tlsproxyprotov2/`
and one under `docs/` — none matching the filter. No image was built:

| | |
|---|---|
| main tip | `36793f54` (2026-08-18 09:54 KST) |
| last `Docker-Multi-Arch` run | 2026-08-12, `Merge pull request #1109` |
| `:latest` amd64 `created` | `2026-08-12T05:49:30Z` |

So for six days `:latest` carried **none** of the ppv2 fixes — including the two
that #675 reporters were being asked to retest. It only moved after a manual
`workflow_dispatch` today, whose image passes all five `cicd/tlsproxyprotov2`
cases (CONTROL-1/2, REPRO, REPRO-2 `doff==20`, REPRO-3 checksum).

Seven datapath-only bumps have landed since `v0.9.8.4` in this exact shape. The
earlier ones were rebuilt only because unrelated files happened to ride along in
the same push — never because the filter worked.

## Why it stayed invisible

The sanity suites have no `paths:` filter, so all 16 ran on that push and it
looked fully green. The one workflow that did not run is the one nobody gets a
notification about.

## Fix

List both forms. `'loxilb-ebpf'` catches the gitlink; `'loxilb-ebpf/**'` stays
for the day the submodule is vendored in-tree.

## Note for the reviewer

This does not backfill anything — `:latest` was already rebuilt manually. The
change only affects which future pushes trigger a build, and it strictly widens
the trigger: pushes that build today keep building.