### PR TITLE
cicd/tlsproxyprotov2: make the scenario runnable from a clean checkout

### DIFF
--- a/cicd/tlsproxyprotov2/config.sh
+++ b/cicd/tlsproxyprotov2/config.sh
@@ -101,8 +101,14 @@ echo "#########################################"
 
 # Cert is issued for the VIP the client dials (10.10.10.254) and lives on the
 # BACKENDS (nginx terminates TLS). Client uses curl --insecure.
+#
+# Use the shared binary rather than a per-scenario copy: ./minica was never
+# committed here, so this scenario could not run from a clean checkout at all.
+# ../common/minica is what cicd/common.sh already calls. It writes the CA pair
+# into the current directory, so the cleanup below and in rmconfig.sh still
+# match.
 rm -fr 10.10.10.254 minica*.pem
-./minica -ip-addresses 10.10.10.254
+../common/minica -ip-addresses 10.10.10.254
 cp 10.10.10.254/cert.pem 10.10.10.254/server.crt
 cp 10.10.10.254/key.pem  10.10.10.254/server.key
 

--- a/cicd/tlsproxyprotov2/rmconfig.sh
+++ b/cicd/tlsproxyprotov2/rmconfig.sh
@@ -18,7 +18,9 @@ delete_docker_host l3ep1
 delete_docker_host l3ep2
 delete_docker_host l3ep3
 
-rm -rf 10.10.10.254/ minica.pem minica-key.pem nginx.l3ep*.conf apt.l3ep*.log
+# apt.*.log rather than apt.l3ep*.log: config.sh also installs ethtool on l3h1
+# and llb1, and those two logs were being left behind on every teardown.
+rm -rf 10.10.10.254/ minica.pem minica-key.pem nginx.l3ep*.conf apt.*.log
 
 echo "#########################################"
 echo "Deleted testbed"


### PR DESCRIPTION
## Problem

`config.sh` calls `./minica`, but that binary was never committed in this
directory. Other scenarios (`cicd/common/`, `cicd/httpsproxy/`, `cicd/httpsep/`,
…) each carry their own copy; this one has none. On a fresh clone:

```
./config.sh: line 105: ./minica: No such file or directory
cp: cannot stat '10.10.10.254/cert.pem': No such file or directory
nginx: [emerg] cannot load certificate "/etc/nginx/certs/server.crt"
```

## Why it matters more than a missing file

The failure does not look like a missing file — it looks like a datapath bug.
nginx refuses to start without its certificate, so **every** case fails,
including the `CONTROL-1` baseline:

```
CONTROL-1  default MTU, offload ON     TLS1.2 -> FAIL   TLS1.3 -> FAIL
CONTROL-2  MTU=320, offload OFF        TLS1.3 -> FAIL
REPRO      MTU=320, offload ON         openssl TLS1.3 -> FAIL
REPRO-2    timestamps OFF (doff=20)    TLS1.3 -> FAIL
REPRO-3    loxilb TX csum offload OFF  TLS1.3 -> FAIL
```

`validation.sh` does call this correctly (`RESULT: inconclusive — even the
single-segment control failed`), but anyone reading the five FAIL lines first
has to work out that the harness, not the datapath, is broken. This scenario is
in no workflow, so nothing ever caught it.

## Fix

Point at `../common/minica`, which is committed and is already what
`cicd/common.sh:27` calls. No new 4 MB binary in the tree. It writes the CA pair
into the current directory, so the existing cleanup in `config.sh` and
`rmconfig.sh` still matches.

## Also

`rmconfig.sh` cleaned `apt.l3ep*.log`, but `config.sh` also installs ethtool on
`l3h1` and `llb1` (lines 70-71) and logs to `apt.l3h1.log` / `apt.llb1.log`.
Those two survived every teardown as untracked junk. Widened to `apt.*.log`.

Not touched: `cert/` and `loxilb.io/` also survive teardown, but they are
gitignored (`.gitignore:51-52`) and `common.sh` caches them deliberately
(`if [ ! -d loxilb.io ]`), so removing them would just force regeneration on
every run and diverge from every other scenario.

## Verification

With no `minica` in the directory, against `ghcr.io/loxilb-io/loxilb:latest`:

- `config.sh` — certificate generated, all three nginx backends start
- `validation.sh` — `RESULT: FIXED`, all five cases OK, exit 0
- `rmconfig.sh` — directory left holding only the tracked files plus the
  gitignored `cert/` and `loxilb.io/`