### PR TITLE
loxinet: send VIP gratuitous ARP via the external egress interface

### DIFF
--- a/pkg/loxinet/rules.go
+++ b/pkg/loxinet/rules.go
@@ -3464,6 +3464,16 @@ func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool) erro
 			R.zone.L3.IfaDelete(dev, utils.IPHostCIDRString(IP))
 		}
 		ev, _, iface := R.zone.L3.IfaSelectAny(IP, false)
+		if ev != 0 || iface == "" || iface == "lo" {
+			// A VIP bound to lo (or one outside every local subnet) has no
+			// L2-adjacent interface of its own. Derive the egress interface
+			// from the system routing table instead, so the gratuitous ARP
+			// always leaves via the actual external-facing interface.
+			if rtIface := utils.RouteGetEgressIfName(IP); rtIface != "" {
+				iface = rtIface
+				ev = 0
+			}
+		}
 		if ev == 0 {
 			ifname := "lo"
 			if tk.IsNetIPv6(IP.String()) {

--- a/pkg/utils/net.go
+++ b/pkg/utils/net.go
@@ -264,6 +264,10 @@ func IsIPHostNetAddr(ip net.IP) bool {
 
 // NetAdvertiseVIP4Req - sends a gratuitous arp reply given the DIP, SIP and interface name
 func NetAdvertiseVIP4Req(AdvIP net.IP, ifName string) (int, error) {
+	if AdvIP == nil || ifName == "" || ifName == "lo" {
+		return -1, errors.New("invalid parameters")
+	}
+
 	bcAddr := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_DGRAM, int(tk.Htons(syscall.ETH_P_ARP)))
 	if err != nil {
@@ -513,6 +517,60 @@ func ArpResolver(dIP uint32) {
 		}
 		return
 	}
+}
+
+// routeLinkName - Given a route, return the name of its egress link.
+// Returns "" when the link can not be resolved or is a loopback (e.g. the
+// local route of a VIP bound to lo)
+func routeLinkName(r nlp.Route) string {
+	link, err := nlp.LinkByIndex(r.LinkIndex)
+	if err != nil {
+		return ""
+	}
+	attrs := link.Attrs()
+	if attrs.Flags&net.FlagLoopback != 0 {
+		return ""
+	}
+	return attrs.Name
+}
+
+// RouteGetEgressIfName - Select the egress interface for reaching dst as per
+// the system routing table. Lookup results on loopback (e.g. the local route
+// of a VIP bound to lo) are skipped, falling back to the egress interface of
+// the default route. Returns "" when no usable egress interface is found.
+func RouteGetEgressIfName(dst net.IP) string {
+	v6 := dst != nil && dst.To4() == nil
+
+	if dst != nil {
+		if routes, err := nlp.RouteGet(dst); err == nil {
+			for _, r := range routes {
+				if name := routeLinkName(r); name != "" {
+					return name
+				}
+			}
+		}
+	}
+
+	// dst may only resolve to a local route on lo; use the default route's
+	// egress interface (the external-facing interface) in that case
+	family := nlp.FAMILY_V4
+	if v6 {
+		family = nlp.FAMILY_V6
+	}
+	routes, err := nlp.RouteList(nil, family)
+	if err != nil {
+		return ""
+	}
+	for _, r := range routes {
+		if r.Dst != nil && !r.Dst.IP.IsUnspecified() {
+			continue
+		}
+		if name := routeLinkName(r); name != "" {
+			return name
+		}
+	}
+
+	return ""
 }
 
 func MkTunFsIfNotExist() error {


### PR DESCRIPTION
## Problem

When a VIP is bound to `lo` (the default for IPv4 LB rules), the gratuitous
ARP announcing that VIP can end up being transmitted on `lo` itself (with an
all-zero sender MAC) or not be sent at all, instead of leaving through the
actual external-facing interface. Upstream neighbors never (re)learn the VIP,
so traffic to it is dropped or blackholed after a failover or refresh.

## Root cause

`AdvRuleVIP()` (pkg/loxinet/rules.go) picks the advertisement interface with
`IfaSelectAny(IP, false)`:

1. With `findAny=false`, selection only succeeds when the VIP falls inside a
   non-lo interface's subnet. For routed VIPs (outside every local subnet) it
   returns an error and the whole VIP-bind + GARP block is silently skipped.
2. Once the VIP is bound to `lo`, a FIB lookup for the VIP only matches the
   local /32 on `lo`, so no L2-adjacent interface can be derived from it.
3. `NetAdvertiseVIP4Req()` (pkg/utils/net.go) has no loopback guard — unlike
   its IPv6 twin `NetAdvertiseVI64Req()`, which already rejects `lo`. If `lo`
   reaches this call, the GARP goes out on loopback.

## Fix

- `pkg/utils/net.go`: add `RouteGetEgressIfName()` — resolve the egress
  interface for a destination from the kernel routing table via netlink
  (`RouteGet`), skipping loopback results (e.g. the local route of a VIP
  bound to `lo`), falling back to the default route's egress interface.
- `pkg/loxinet/rules.go` (`AdvRuleVIP`): whenever `IfaSelectAny` fails or
  yields `""`/`"lo"`, resolve the interface with `RouteGetEgressIfName()`.
  The v4 GARP, the v6 NA and the v6 VIP bind path all use the corrected
  interface.
- `pkg/utils/net.go` (`NetAdvertiseVIP4Req`): reject `nil` IP, empty and `lo`
  interface names, mirroring `NetAdvertiseVI64Req()`.

Behavior after the change:

- VIP stays bound to `lo` for IPv4 (unchanged), but the GARP always leaves
  via the routed external interface carrying that interface's MAC.
- Routed VIPs (outside local subnets) are now bound and advertised instead of
  being silently skipped.
- IPv6 neighbor advertisements benefit from the same fallback.