### PR TITLE
route: don't abort rt delete on a trie miss

### DIFF
--- a/pkg/loxinet/route.go
+++ b/pkg/loxinet/route.go
@@ -420,11 +420,21 @@ func (r *RtH) rtDeleteCommon(Dst net.IPNet, Zone string, host bool) (int, error)
 		tR = r.Trie6
 	}
 	ones, _ := Dst.Mask.Size()
-	if (ones != 32 && ones != 128) || !r.Zone.Rules.IsIPRuleVIP(Dst.IP) {
-		tret := tR.DelTrie(Dst.String())
-		if tret != 0 {
+	// Always attempt the trie delete. RtAdd skips the trie insert for host routes
+	// that were rule VIPs at insert time, and IsIPRuleVIP is not guaranteed to
+	// return the same answer at delete time, so the condition goes wrong in both
+	// directions - it leaves stale trie entries behind, and it makes an expected
+	// miss abort the rest of the cleanup. Keep going on a miss: bailing out here
+	// used to leak the RtMap entry, the route mark and the datapath self-route on
+	// every rule VIP removal.
+	if tret := tR.DelTrie(Dst.String()); tret != 0 {
+		if ones == 32 || ones == 128 {
+			// The rule VIP delete path hits this on every removal, so a host
+			// route miss stays at debug. This does cost us the double-delete
+			// signal for host routes, which has no other marker left by then.
+			tk.LogIt(tk.LogDebug, "rt delete - %s:%s lpm not found\n", Dst.String(), Zone)
+		} else {
 			tk.LogIt(tk.LogError, "rt delete - %s:%s lpm not found\n", Dst.String(), Zone)
-			return RtTrieDelErr, errors.New("rt-lpm delete error")
 		}
 	}
 

--- a/pkg/loxinet/route_test.go
+++ b/pkg/loxinet/route_test.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2022 NetLOX Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loxinet
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	opts "github.com/loxilb-io/loxilb/options"
+	tk "github.com/loxilb-io/loxilib"
+)
+
+// ensureLoxinet - bring up the stack these tests need. TestLoxinet usually gets
+// there first; loxiNetInit must not run twice.
+func ensureLoxinet(t *testing.T) {
+	t.Helper()
+
+	if mh.zr != nil {
+		return
+	}
+
+	// loxiNetInit calls log.Fatal when it cannot open its log file, which would
+	// take the whole test binary down. Check first and skip instead.
+	logfile := fmt.Sprintf("/var/log/loxilb%s.log", os.Getenv("HOSTNAME"))
+	f, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		t.Skipf("needs write access to %s: %v", logfile, err)
+	}
+	f.Close()
+
+	opts.Opts.NoNlp = true
+	opts.Opts.NoAPI = true
+	opts.Opts.CPUProfile = "none"
+	opts.Opts.Prometheus = false
+	opts.Opts.K8sAPI = "none"
+	opts.Opts.ClusterNodes = "none"
+	// These tests only look at RtMap, the trie and the mark pool. Keep eBPF out
+	// of it so a run does not touch the host's TC hooks.
+	opts.Opts.ProxyModeOnly = true
+
+	loxiNetInit()
+
+	if mh.zr == nil {
+		t.Fatal("loxinet init failed")
+	}
+}
+
+// newTestRtH - a private route table over the initialized zone, so a test can
+// pick its own mark pool size and not disturb the shared one.
+func newTestRtH(marks uint64) *RtH {
+	r := new(RtH)
+	r.RtMap = make(map[RtKey]*Rt)
+	r.Trie4 = tk.TrieInit(false)
+	r.Trie6 = tk.TrieInit(true)
+	r.Zone = mh.zr
+	r.Mark = tk.NewCounter(1, marks)
+	return r
+}
+
+func hostCIDR(t *testing.T, ip string) net.IPNet {
+	t.Helper()
+	_, dst, err := net.ParseCIDR(ip + "/32")
+	if err != nil {
+		t.Fatalf("parse %s: %v", ip, err)
+	}
+	return *dst
+}
+
+// TestRtDeleteVIPHostRouteReclaimsMark - a rule VIP's self-route must free its
+// RtMap entry and its route mark on delete, even though RtAdd never put it in
+// the trie so the trie delete misses.
+//
+// This is the LoadBalancer service churn path. DeleteRuleVIP drops the vipMap
+// entry synchronously, while the kernel address event that deletes the route
+// arrives later, so IsIPRuleVIP disagrees between insert and delete. Before the
+// fix the miss aborted rtDeleteCommon and every distinct VIP leaked one entry
+// and one mark for the lifetime of the process.
+func TestRtDeleteVIPHostRouteReclaimsMark(t *testing.T) {
+	ensureLoxinet(t)
+
+	const marks = 8
+	r := newTestRtH(marks)
+
+	// More rounds than the pool holds: a leaked mark per round exhausts it.
+	for i := 0; i < marks*3; i++ {
+		vip := fmt.Sprintf("198.51.100.%d", i+1)
+		dst := hostCIDR(t, vip)
+
+		// The rule exists when the address, and so the self-route, is added.
+		mh.zr.Rules.vipMap[vip] = &vipElem{ref: 1}
+
+		ret, err := r.RtAdd(dst, RootZone, RtAttr{Ifi: -1}, nil)
+		if ret != 0 || err != nil {
+			t.Fatalf("round %d: rt add %s: ret %d err %v", i, vip, ret, err)
+		}
+
+		rt := r.RtFind(dst, RootZone)
+		if rt == nil {
+			t.Fatalf("round %d: rt add %s: not in RtMap", i, vip)
+		}
+		if rt.Mark == ^uint64(0) {
+			t.Fatalf("round %d: rt add %s: mark pool exhausted", i, vip)
+		}
+
+		// RtAdd keeps rule VIP host routes out of the trie.
+		if terr, _, _ := r.Trie4.FindTrie(vip); terr == 0 {
+			t.Fatalf("round %d: %s unexpectedly in trie", i, vip)
+		}
+
+		// DeleteRuleVIP forgets the VIP before the address event lands.
+		delete(mh.zr.Rules.vipMap, vip)
+
+		ret, err = r.RtDelete(dst, RootZone)
+		if ret != 0 || err != nil {
+			t.Fatalf("round %d: rt delete %s: ret %d err %v", i, vip, ret, err)
+		}
+		if r.RtFind(dst, RootZone) != nil {
+			t.Fatalf("round %d: rt delete %s: still in RtMap", i, vip)
+		}
+	}
+
+	if len(r.RtMap) != 0 {
+		t.Fatalf("RtMap holds %d entries after %d add/delete rounds", len(r.RtMap), marks*3)
+	}
+}
+
+// TestRtDeleteClearsTrieEntryAddedBeforeVIP - the other direction of the same
+// disagreement. A host route that entered the trie before its rule was
+// registered must still leave the trie on delete.
+func TestRtDeleteClearsTrieEntryAddedBeforeVIP(t *testing.T) {
+	ensureLoxinet(t)
+
+	r := newTestRtH(16)
+
+	const vip = "203.0.113.7"
+	dst := hostCIDR(t, vip)
+
+	// No rule yet, so RtAdd does put this one in the trie.
+	if ret, err := r.RtAdd(dst, RootZone, RtAttr{Ifi: -1}, nil); ret != 0 || err != nil {
+		t.Fatalf("rt add %s: ret %d err %v", vip, ret, err)
+	}
+	if terr, _, _ := r.Trie4.FindTrie(vip); terr != 0 {
+		t.Fatalf("rt add %s: expected a trie entry", vip)
+	}
+
+	// The rule shows up afterwards, e.g. NlpGet racing rule registration.
+	mh.zr.Rules.vipMap[vip] = &vipElem{ref: 1}
+	defer delete(mh.zr.Rules.vipMap, vip)
+
+	if ret, err := r.RtDelete(dst, RootZone); ret != 0 || err != nil {
+		t.Fatalf("rt delete %s: ret %d err %v", vip, ret, err)
+	}
+	if terr, _, _ := r.Trie4.FindTrie(vip); terr == 0 {
+		t.Fatalf("rt delete %s: trie entry left behind", vip)
+	}
+}


### PR DESCRIPTION
### What

`rtDeleteCommon` gated the trie delete on `IsIPRuleVIP` and returned `RtTrieDelErr` when `DelTrie` missed. `RtAdd` applies the same condition at insert time, but the two moments can disagree, and the early return skipped the rest of the cleanup.

### The chain

1. `DeleteRuleVIP` removes the kernel address, then drops the `vipMap` entry synchronously.
2. The kernel `RTM_DELADDR` that drives the matching route delete is consumed by `AUWorker` up to 500ms later.
3. By then `IsIPRuleVIP` is `false`, so `rtDeleteCommon` tries to remove a trie entry that `RtAdd` never inserted, because at insert time the VIP *was* registered.
4. The miss returns before `delete(r.RtMap, ...)`, `rt.DP(DpRemove)` and `Mark.PutCounter`.

So every rule VIP removal left an `RtMap` entry, a route mark and a datapath self-route behind. It also happens after `rtClearDeps()` and `NeighUnPairRt`, so a route with nexthops that hits the same miss stays in `RtMap` unpaired from its neighbour.

### Impact

Reusing the same VIP is harmless. A workload that cycles through distinct LoadBalancer IPs accumulates one leak per VIP for the lifetime of the process, against the 40960 `MaxSysRoutes` mark pool that is shared with real routes. Exhaustion is silent: `RtAdd` discards the counter error and hands `^uint64(0)` to the datapath.

```go
// pkg/loxinet/route.go
// If we cant allocate Mark, we don't care
rt.Mark, _ = r.Mark.GetCounter()
...
rtWq.RtMark = int(rt.Mark)
```

### Fix

The condition is wrong in both directions. It also skips the delete for entries that made it into the trie before the rule was registered, leaving them there. So drop it, always attempt the delete, and treat a miss as non-fatal. Host route misses log at debug because the normal VIP delete path hits them on every removal; other prefixes keep the error log.

No caller distinguishes `RtTrieDelErr`. The two that branch on a non-zero return, the `RtAdd` route-change path and `NetRouteDel`, both stop failing on a trie miss.

### Testing

Adds `pkg/loxinet/route_test.go` covering both directions.

- `TestRtDeleteVIPHostRouteReclaimsMark` runs the register / add / unregister / delete cycle over a mark pool of 8 for 24 rounds, so one leaked mark per round exhausts it.
- `TestRtDeleteClearsTrieEntryAddedBeforeVIP` adds the route before the rule exists and checks the trie entry is gone after the delete.

Both fail on the current code (`ret -4993`, and a trie entry left behind) and pass with this change. `TestLoxinet` still passes. The new tests set `ProxyModeOnly` so they do not touch the host's TC hooks.
