### PR TITLE
loxinet: resolve the interface a rule VIP is advertised on

### DIFF
--- a/api/loxinlp/nlp.go
+++ b/api/loxinlp/nlp.go
@@ -1002,8 +1002,72 @@ func AddAddrNoHook(address, ifName string) int {
 	return ret
 }
 
+// delAddrAnyLink - delete an address without being told which link holds it
+//
+// The VIP delete path can get here with nothing resolved, and guessing lo only
+// works for IPv4. The kernel already knows where the address is, so ask it.
+// DelNeighNoHook does the same thing for neighbours.
+func delAddrAnyLink(address string) int {
+	addr, err := nlp.ParseAddr(address)
+	if err != nil {
+		tk.LogIt(tk.LogWarning, "nlp: Address %s Parse Fail\n", address)
+		return -1
+	}
+
+	family := nlp.FAMILY_V4
+	if addr.IP.To4() == nil {
+		family = nlp.FAMILY_V6
+	}
+
+	// A literal nil, never a nil-valued Link: AddrList calls Attrs on anything
+	// that is not nil, so a typed nil would panic instead of listing every link.
+	addrs, err := nlp.AddrList(nil, family)
+	if err != nil {
+		tk.LogIt(tk.LogWarning, "nlp: Address list get Fail: %v\n", err)
+		return -1
+	}
+
+	want, _ := addr.Mask.Size()
+	found := 0
+
+	for i := range addrs {
+		if !addrs[i].IP.Equal(addr.IP) {
+			continue
+		}
+		if ones, _ := addrs[i].Mask.Size(); ones != want {
+			continue
+		}
+
+		link, err := nlp.LinkByIndex(addrs[i].LinkIndex)
+		if err != nil {
+			tk.LogIt(tk.LogWarning, "nlp: Address %v link %d get Fail: %v\n", address, addrs[i].LinkIndex, err)
+			continue
+		}
+		if err := nlp.AddrDel(link, &addrs[i]); err != nil {
+			tk.LogIt(tk.LogWarning, "nlp: Address %v Port %v delete Fail: %v\n", address, link.Attrs().Name, err)
+			return -1
+		}
+
+		tk.LogIt(tk.LogInfo, "nlp: Address %v Port %v deleted\n", address, link.Attrs().Name)
+		found++
+	}
+
+	if found == 0 {
+		// Someone else got there first. Nothing to undo, so this is not a
+		// failure the caller should report.
+		tk.LogIt(tk.LogDebug, "nlp: Address %v not on any link\n", address)
+	} else if found > 1 {
+		tk.LogIt(tk.LogWarning, "nlp: Address %v was on %d links\n", address, found)
+	}
+
+	return 0
+}
+
 func DelAddrNoHook(address, ifName string) int {
 	var ret int
+	if ifName == "" {
+		return delAddrAnyLink(address)
+	}
 	IfName, err := nlp.LinkByName(ifName)
 	if err != nil {
 		_, err := hooks.NetAddrDel(&cmn.IPAddrMod{Dev: ifName, IP: address})

--- a/cicd/ha1-vipadv/README.md
+++ b/cicd/ha1-vipadv/README.md
@@ -1,0 +1,99 @@
+# ha1-vipadv
+
+Regression case for VIP advertisement: which interface a load balancer rule's
+VIP is bound to, advertised on, and removed from as HA state changes.
+
+Derived from `ha1`, which supplies the topology this needs — a VIP that is not
+in any subnet the load balancers hold, reachable only through a static route on
+the upstream router.
+
+## Topology
+
+```
+                        vlan11 (bridge, 11.11.11.0/24, 2001:db8:11::/64)
+  user ---- r1 ---------+---- llb1
+  1.1.1.1   1.1.1.254   |     11.11.11.1   2001:db8:11::1
+                        +---- llb2
+                        |     11.11.11.2   2001:db8:11::2
+                        +---- ep1  11.11.11.3
+                        +---- ep2  11.11.11.4
+                        +---- ep3  11.11.11.5
+```
+
+Two VIPs, each covering a different resolution path:
+
+| VIP | Reachability | Bound on |
+| --- | --- | --- |
+| `20.20.20.1` | routed, `r1` holds a static `/32` towards the VLAN | `lo` |
+| `2001:db8:11::100` | L2 adjacent, inside the VLAN 11 subnet | `vlan11` |
+
+`20.20.20.1` is in no subnet either load balancer holds, and neither has a route
+to it. That is the case where an advertise interface cannot be derived from the
+local addresses alone.
+
+## What it checks
+
+Before and after an HA transition:
+
+- the IPv4 VIP is bound on `lo` on the master and absent on the backup
+- the IPv6 VIP sits on `vlan11` on the master and is absent on the backup
+- which interface each VIP resolved to, read back from the load balancer's log
+- a gratuitous ARP for the IPv4 VIP reaches `r1` on the VLAN, and reaches it
+  again on a later sweep
+
+The repeat matters. A resolver that asks the kernel for a route to the VIP gets
+`local ... dev lo` back once the VIP is bound, so it works on the first pass and
+goes wrong on every one after it. The VIP sweep runs roughly every 40 seconds,
+so the second capture window is what a first pass alone would not catch.
+
+## Modes
+
+`VIP_ADV_DEV` selects how the advertise interface is chosen. It is passed to
+both scripts.
+
+```bash
+./config.sh && ./validation.sh && ./rmconfig.sh              # --vip-adv-dev vlan11
+VIP_ADV_DEV= ./config.sh && VIP_ADV_DEV= ./validation.sh     # automatic
+```
+
+Default is `vlan11`, which pins the advertisement with `--vip-adv-dev`.
+
+With `VIP_ADV_DEV` empty the load balancers resolve on their own, and in this
+topology they land on the container's default route, not the VLAN. That is the
+correct answer for the routing table they have: neither has a route to
+`20.20.20.1`, so the only main table route covering it is the default one. It is
+also why the option exists. The gratuitous ARP assertion is dropped in this
+mode; the rest still applies, and the IPv4 VIP is still expected on `lo` — an
+interface that cannot be advertised on must not stop the VIP from being bound.
+
+## HA transitions
+
+State is driven through the load balancer's own API rather than keepalived:
+
+```
+POST /netlox/v1/config/cistate {"instance":"llb-inst0","state":"BACKUP", ...}
+```
+
+`llb-inst0` is the instance a rule created without one belongs to. The API
+returns instances in no fixed order, so the scripts select it by name.
+
+The load balancers are still spawned in cluster mode, with each other as peers,
+which is what settles the initial master and backup. What the case does not use
+is the separate keepalived container `ha1` expects: its failover is a
+`docker restart ka_$master`, and no such container is started here.
+
+That has a second consequence. The case does not exercise the data path, because
+`ha1`'s traffic test uses the keepalived VRRP address as the endpoint gateway
+and that address does not exist without it.
+
+## Out of scope
+
+- data path correctness, per above
+- resolution of a *routed* IPv6 VIP. The IPv6 VIP here is L2 adjacent, so it
+  exercises the address-follows-the-port rule and the removal path, not a route
+  lookup. A routed IPv6 VIP needs IPv6 routing on the upstream router.
+
+## Requirements
+
+`tcpdump` on the host. The gratuitous ARP capture runs in `r1`'s namespace with
+the host's binary; the check is skipped, not failed, when it is missing.

--- a/cicd/ha1-vipadv/config.sh
+++ b/cicd/ha1-vipadv/config.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+source ../common.sh
+
+echo "#########################################"
+echo "Spawning all hosts"
+echo "#########################################"
+
+# --vip-adv-dev pins the advertisement to the VLAN 11 segment. Automatic
+# resolution cannot get this topology right: llb1 and llb2 have no route to
+# 20.20.20.1 of their own, so the only main table route covering the VIP is the
+# docker default route out of eth0, and eth0 is a loxilb port like any other.
+# That is the multi-homed case the option exists for.
+#
+# Set VIP_ADV_DEV empty to run the same topology on automatic resolution, and
+# pass the same value to validation.sh so it knows to drop the GARP assertion.
+advdev="${VIP_ADV_DEV-vlan11}"
+adv_args=""
+if [[ -n "$advdev" ]]; then
+    adv_args="--vip-adv-dev $advdev"
+fi
+
+spawn_docker_host --dock-type loxilb --dock-name llb1 --with-ka out --ka-config $(pwd)/keepalived_config --extra-args "$adv_args"
+spawn_docker_host --dock-type loxilb --dock-name llb2 --with-ka out --ka-config $(pwd)/keepalived_config --extra-args "$adv_args"
+spawn_docker_host --dock-type host --dock-name ep1
+spawn_docker_host --dock-type host --dock-name ep2
+spawn_docker_host --dock-type host --dock-name ep3
+spawn_docker_host --dock-type host --dock-name r1
+spawn_docker_host --dock-type host --dock-name user
+
+echo "#########################################"
+echo "Connecting and configuring  hosts"
+echo "#########################################"
+
+
+connect_docker_hosts user r1
+connect_docker_hosts r1 llb1
+connect_docker_hosts r1 llb2
+connect_docker_hosts r1 ep1
+connect_docker_hosts r1 ep2
+connect_docker_hosts r1 ep3
+
+#node1 config
+config_docker_host --host1 user --host2 r1 --ptype phy --addr 1.1.1.1/24 --gw 1.1.1.254
+config_docker_host --host1 r1 --host2 user --ptype phy --addr 1.1.1.254/24
+
+create_docker_host_vlan --host1 r1 --host2 llb1 --id 11 --ptype untagged
+create_docker_host_vlan --host1 r1 --host2 llb2 --id 11 --ptype untagged
+config_docker_host --host1 r1 --host2 llb1 --ptype vlan --id 11 --addr 11.11.11.254/24
+
+create_docker_host_vlan --host1 llb1 --host2 r1 --id 11 --ptype untagged
+config_docker_host --host1 llb1 --host2 r1 --ptype vlan --id 11 --addr 11.11.11.1/24
+
+create_docker_host_vlan --host1 llb2 --host2 r1 --id 11 --ptype untagged
+config_docker_host --host1 llb2 --host2 r1 --ptype vlan --id 11 --addr 11.11.11.2/24
+
+
+create_docker_host_vlan --host1 r1 --host2 ep1 --id 11 --ptype untagged
+create_docker_host_vlan --host1 r1 --host2 ep2 --id 11 --ptype untagged
+create_docker_host_vlan --host1 r1 --host2 ep3 --id 11 --ptype untagged
+
+
+##Pod networks
+config_docker_host --host1 ep1 --host2 r1 --ptype phy --addr 11.11.11.3/24 --gw 11.11.11.11
+config_docker_host --host1 ep2 --host2 r1 --ptype phy --addr 11.11.11.4/24 --gw 11.11.11.11
+config_docker_host --host1 ep3 --host2 r1 --ptype phy --addr 11.11.11.5/24 --gw 11.11.11.11
+
+##IPv6 on the same segment
+# spawn_docker_host turns IPv6 off in every container, and clearing the global
+# knob does not reach vlan11, which already exists by now, so clear that one too.
+for h in r1 llb1 llb2; do
+  $hexec $h sysctl -w net.ipv6.conf.all.disable_ipv6=0 >/dev/null 2>&1
+  $hexec $h sysctl -w net.ipv6.conf.default.disable_ipv6=0 >/dev/null 2>&1
+  $hexec $h sysctl -w net.ipv6.conf.vlan11.disable_ipv6=0 >/dev/null 2>&1
+done
+
+$hexec r1   ip -6 addr add 2001:db8:11::254/64 dev vlan11 nodad
+$hexec llb1 ip -6 addr add 2001:db8:11::1/64 dev vlan11 nodad
+$hexec llb2 ip -6 addr add 2001:db8:11::2/64 dev vlan11 nodad
+
+$hexec r1 ip route add 20.20.20.1/32 via 11.11.11.11
+add_route llb1 1.1.1.0/24 11.11.11.254
+add_route llb2 1.1.1.0/24 11.11.11.254
+
+sleep 1
+
+##Create LB rule
+create_lb_rule llb1 20.20.20.1 --tcp=2020:8080 --endpoints=11.11.11.3:1,11.11.11.4:1,11.11.11.5:1 --mode=fullnat
+create_lb_rule llb2 20.20.20.1 --tcp=2020:8080 --endpoints=11.11.11.3:1,11.11.11.4:1,11.11.11.5:1 --mode=fullnat
+
+##IPv6 VIP, L2 adjacent to the VLAN 11 subnet
+# Traffic to this one is not exercised - the endpoints have no IPv6 of their
+# own. It is here for where the /128 ends up: the master must carry it and the
+# backup must not, which is what the add and delete paths have to agree on.
+create_lb_rule llb1 2001:db8:11::100 --tcp=2020:8080 --endpoints=2001:db8:11::3:1 --mode=fullnat
+create_lb_rule llb2 2001:db8:11::100 --tcp=2020:8080 --endpoints=2001:db8:11::3:1 --mode=fullnat
+
+# keepalive will take few seconds to be UP and running with valid states
+sleep 10

--- a/cicd/ha1-vipadv/keepalived_config/keepalived.conf
+++ b/cicd/ha1-vipadv/keepalived_config/keepalived.conf
@@ -1,0 +1,22 @@
+! Configuration File for keepalived
+
+global_defs {
+   smtp_server localhost
+   smtp_connect_timeout 30
+}
+
+vrrp_instance default {
+    state MASTER
+    interface vlan11
+    virtual_router_id 101
+    priority 100
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass 1111
+    }
+    virtual_ipaddress {
+        11.11.11.11
+    }
+    notify "/container/service/keepalived/assets/notify.sh"
+}

--- a/cicd/ha1-vipadv/keepalived_config/notify.sh
+++ b/cicd/ha1-vipadv/keepalived_config/notify.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo $1 $2 is in $3 state > /root/keepalive.state
+curl -X 'POST' 'http://0.0.0.0:11111/netlox/v1/config/cistate' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{ "instance": "'$2'", "state" : "'$3'" }'

--- a/cicd/ha1-vipadv/rmconfig.sh
+++ b/cicd/ha1-vipadv/rmconfig.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "#########################################"
+echo "Removing testbed"
+echo "#########################################"
+
+source ../common.sh
+
+disconnect_docker_hosts user r1
+disconnect_docker_hosts r1 llb1
+disconnect_docker_hosts r1 llb2
+disconnect_docker_hosts r1 ep1
+disconnect_docker_hosts r1 ep2
+disconnect_docker_hosts r1 ep3
+
+delete_docker_host llb1
+delete_docker_host llb2
+delete_docker_host user
+delete_docker_host r1
+delete_docker_host ep1
+delete_docker_host ep2
+delete_docker_host ep3
+
+echo "#########################################"
+echo "Removed testbed"
+echo "#########################################"

--- a/cicd/ha1-vipadv/validation.sh
+++ b/cicd/ha1-vipadv/validation.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+source ../common.sh
+echo VIPADV
+
+##
+## VIP advertisement, derived from the HA-1 topology.
+##
+## What this checks: a routed IPv4 VIP is bound on the master and advertised on
+## the data plane link, the advertisement repeats on later sweeps, the IPv6 VIP
+## sits on the port that answers for it, and both leave a demoted master.
+##
+## What it does not check: the data path. HA-1's traffic test needs the
+## keepalived VRRP address as the endpoint gateway, and this case drives HA
+## state through loxilb's own API instead of running keepalived, so that
+## address does not exist here. Resolution of a routed IPv6 VIP is out of scope
+## too - the IPv6 VIP here is L2 adjacent.
+##
+## VIP_ADV_DEV picks the mode. Set it empty to let loxilb resolve the interface
+## on its own; the GARP assertion is then dropped, because in this topology
+## neither loxilb has a route to the VIP and automatic resolution correctly
+## lands on whatever the default route points at.
+##
+
+v4vip="20.20.20.1"
+v6vip="2001:db8:11::100"
+advdev="${VIP_ADV_DEV-vlan11}"
+code=0
+
+api() {
+    local host=$1 method=$2 path=$3 body=$4
+    if [[ -n "$body" ]]; then
+        $hexec $host curl -sX "$method" "http://0.0.0.0:11111/netlox/v1$path" \
+            -H 'accept: application/json' -H 'Content-Type: application/json' -d "$body"
+    else
+        $hexec $host curl -sX "$method" "http://0.0.0.0:11111/netlox/v1$path" \
+            -H 'accept: application/json'
+    fi
+}
+
+# A rule created without an instance lands on cmn.CIDefault, which is the
+# string "llb-inst0" - not the instance literally named "default", which the
+# cluster arguments create separately. Select by name: the API returns the
+# instances in no particular order, and the order differs between the two hosts.
+ci_inst="llb-inst0"
+
+ci_state() {
+    api $1 GET /config/cistate/all | jq -r --arg i "$ci_inst" '.Attr[] | select(.instance==$i) | .state'
+}
+
+# set_ci_state <host> <MASTER|BACKUP> - drive HA state without keepalived
+set_ci_state() {
+    api $1 POST /config/cistate "{\"instance\":\"$ci_inst\",\"state\":\"$2\",\"vip\":\"0.0.0.0\"}" >/dev/null
+}
+
+vip4_on_lo() {
+    $hexec $1 ip -4 -o addr show dev lo 2>/dev/null | grep -q "$v4vip/32"
+}
+
+# vip6_dev <host> - which link carries the IPv6 VIP, empty for none
+vip6_dev() {
+    $hexec $1 ip -6 -o addr show 2>/dev/null | grep "$v6vip/128" | awk '{print $2}' | head -1
+}
+
+# adv_if <host> <vip> - the interface loxilb last reported for a VIP
+#
+# loxilb names its log file after HOSTNAME, which docker sets to the container
+# id, so glob for it.
+adv_if() {
+    $dexec $1 bash -c "grep -h 'lb-rule vip $2 - advertising on' /var/log/loxilb*.log 2>/dev/null | tail -1" \
+        | sed -E 's/.*advertising on ([^ ,]+).*/\1/'
+}
+
+# garp_seen <seconds> - a gratuitous ARP for the v4 VIP on r1's VLAN 11
+#
+# arp[14:4] is the sender protocol address, so only frames claiming 20.20.20.1
+# match. The VIP sweep comes round about every 40 seconds.
+garp_seen() {
+    local out
+    out=$($hexec r1 timeout $1 tcpdump -l -n -i vlan11 -c 1 \
+          'arp and arp[14:4] = 0x14141401' 2>/dev/null)
+    [[ -n "$out" ]]
+}
+
+check_vip_adv() {
+    local master=$1 backup=$2 phase=$3
+    local rc=0
+
+    if vip4_on_lo $master; then
+        echo "VIPADV $phase vip4 bound on $master [OK]"
+    else
+        echo "VIPADV $phase vip4 not bound on $master [FAILED]"
+        rc=1
+    fi
+
+    if vip4_on_lo $backup; then
+        echo "VIPADV $phase vip4 still bound on backup $backup [FAILED]"
+        rc=1
+    else
+        echo "VIPADV $phase vip4 absent on backup $backup [OK]"
+    fi
+
+    local mdev=$(vip6_dev $master)
+    local bdev=$(vip6_dev $backup)
+
+    if [[ "$mdev" == "vlan11" ]]; then
+        echo "VIPADV $phase vip6 on $master vlan11 [OK]"
+    else
+        echo "VIPADV $phase vip6 on $master is '${mdev:-none}', want vlan11 [FAILED]"
+        rc=1
+    fi
+
+    if [[ -z "$bdev" ]]; then
+        echo "VIPADV $phase vip6 absent on backup $backup [OK]"
+    else
+        echo "VIPADV $phase vip6 still on backup $backup dev $bdev [FAILED]"
+        rc=1
+    fi
+
+    echo "VIPADV $phase resolved v4 '$(adv_if $master $v4vip)' v6 '$(adv_if $master $v6vip)' on $master"
+
+    if [[ -z "$advdev" ]]; then
+        echo "VIPADV $phase garp assertion skipped, automatic resolution mode"
+        return $rc
+    fi
+    if ! command -v tcpdump >/dev/null 2>&1; then
+        echo "VIPADV $phase garp check skipped, no tcpdump on the host"
+        return $rc
+    fi
+
+    # Two windows back to back. The first says the VIP is advertised at all, the
+    # second that the periodic re-advertisement keeps going - which is where a
+    # RouteGet based resolver stops, because once the VIP is bound the kernel
+    # answers with the local route on lo.
+    if garp_seen 60; then
+        echo "VIPADV $phase garp seen on r1 vlan11 [OK]"
+    else
+        echo "VIPADV $phase no garp on r1 vlan11 [FAILED]"
+        rc=1
+    fi
+
+    if garp_seen 60; then
+        echo "VIPADV $phase garp repeated on a later sweep [OK]"
+    else
+        echo "VIPADV $phase garp not repeated [FAILED]"
+        rc=1
+    fi
+
+    return $rc
+}
+
+status1=$(ci_state llb1)
+status2=$(ci_state llb2)
+echo "VIPADV HA state llb1-$status1 llb2-$status2  (adv dev '${advdev:-auto}')"
+
+if [[ $status1 == "MASTER" && $status2 == "BACKUP" ]]; then
+    master="llb1"; backup="llb2"
+elif [[ $status2 == "MASTER" && $status1 == "BACKUP" ]]; then
+    master="llb2"; backup="llb1"
+else
+    echo "VIPADV HA state llb1-$status1 llb2-$status2 [FAILED]"
+    exit 1
+fi
+echo "Master:$master Backup:$backup"
+
+check_vip_adv $master $backup Phase-1 || code=1
+
+echo "VIPADV flipping HA state through the API"
+set_ci_state $master BACKUP
+set_ci_state $backup MASTER
+sleep 5
+
+status1=$(ci_state $master)
+status2=$(ci_state $backup)
+echo "VIPADV HA state $master-$status1 $backup-$status2"
+
+if [[ $status1 == "BACKUP" && $status2 == "MASTER" ]]; then
+    echo "VIPADV HA flip [OK]"
+else
+    echo "VIPADV HA flip [FAILED]"
+    exit 1
+fi
+
+# The demoted master has to give both VIPs up, and the promoted one take them.
+# One sweep is about 40 seconds; allow two.
+sleep 90
+check_vip_adv $backup $master Phase-2 || code=1
+
+if [[ $code == 0 ]]; then
+    echo "VIPADV [OK]"
+else
+    echo "VIPADV [FAILED]"
+fi
+
+exit $code

--- a/options/options.go
+++ b/options/options.go
@@ -48,6 +48,7 @@ var Opts struct {
 	ProxyModeOnly        bool           `long:"proxyonlymode" description:"Run loxilb in proxy mode only, no Datapath"`
 	WhiteList            string         `long:"whitelist" description:"Regex string of whitelisted interface(experimental)" default:"none"`
 	ClusterInterface     string         `long:"clusterinterface" description:"cluster interface for egress HA" default:""`
+	VIPAdvDev            string         `long:"vip-adv-dev" description:"interface to advertise LB rule VIPs on, overrides automatic resolution" default:""`
 	UserServiceEnable    bool           `long:"userservice" description:"Enable user service for loxilb"`
 	DatabaseHost         string         `long:"databasehost" description:"Database host" default:"127.0.0.1"`
 	DatabasePort         int            `long:"databaseport" description:"Database port" default:"3306"`

--- a/pkg/loxinet/rules.go
+++ b/pkg/loxinet/rules.go
@@ -2940,13 +2940,17 @@ func (R *RuleH) RulesSync() {
 	}
 
 	if time.Duration(time.Since(R.vipST).Seconds()) > time.Duration(VIPSweepDuration) {
+		// One main table dump for the whole pass, and only if some VIP needs
+		// one. The context is dropped at the end of the sweep: nothing about
+		// the resolution is remembered between passes.
+		advCtx := new(vipAdvCtx)
 		for vip, vipElem := range R.vipMap {
 			ip := vipElem.pVIP
 			if ip == nil {
 				ip = net.ParseIP(vip)
 			}
 			if ip != nil {
-				R.AdvRuleVIP(ip, net.ParseIP(vip), vipElem.inst, vipElem.egr)
+				R.AdvRuleVIP(ip, net.ParseIP(vip), vipElem.inst, vipElem.egr, advCtx)
 			}
 		}
 		R.vipST = time.Now()
@@ -3447,7 +3451,7 @@ func (r *ruleEnt) DP(work DpWorkT) int {
 
 }
 
-func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool) error {
+func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool, ctx *vipAdvCtx) error {
 	if inst == "" {
 		inst = cmn.CIDefault
 	}
@@ -3463,36 +3467,45 @@ func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool) erro
 		if ret == 0 {
 			R.zone.L3.IfaDelete(dev, utils.IPHostCIDRString(IP))
 		}
-		ev, _, iface := R.zone.L3.IfaSelectAny(IP, false)
-		if ev == 0 {
-			ifname := "lo"
-			if tk.IsNetIPv6(IP.String()) {
-				ifname = iface
-			}
-			if !utils.IsIPHostAddr(IP.String()) {
-				if mh.cloudHook != nil {
-					err := mh.cloudHook.CloudUpdatePrivateIP(IP, eIP, true)
-					if err != nil {
-						tk.LogIt(tk.LogError, "%s: lb-rule vip %s add failed. err: %v\n", mh.cloudLabel, IP.String(), err)
-						return err
-					}
-				}
+		iface := R.VipAdvIf(IP, ctx)
 
-				if loxinlp.AddAddrNoHook(utils.IPHostCIDRString(IP), ifname) != 0 {
-					tk.LogIt(tk.LogError, "lb-rule vip %s:%s add failed\n", IP.String(), ifname)
-				} else {
-					tk.LogIt(tk.LogInfo, "lb-rule vip %s:%s added\n", IP.String(), ifname)
+		// Binding the address, the cloud hook and the neighbour cleanup do not
+		// depend on having found somewhere to advertise - only the gratuitous
+		// ARP or NA does, so a VIP whose interface does not resolve is still
+		// bound and still serves. IPv6 is the one exception: its bind target is
+		// the port that answers neighbour solicitations for the address, which
+		// is the very thing that failed to resolve.
+		ifname := "lo"
+		if tk.IsNetIPv6(IP.String()) {
+			ifname = iface
+		}
+
+		if !utils.IsIPHostAddr(IP.String()) && ifname != "" {
+			if mh.cloudHook != nil {
+				err := mh.cloudHook.CloudUpdatePrivateIP(IP, eIP, true)
+				if err != nil {
+					tk.LogIt(tk.LogError, "%s: lb-rule vip %s add failed. err: %v\n", mh.cloudLabel, IP.String(), err)
+					return err
 				}
-				loxinlp.DelNeighNoHook(IP.String(), "")
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+
+			if loxinlp.AddAddrNoHook(utils.IPHostCIDRString(IP), ifname) != 0 {
+				tk.LogIt(tk.LogError, "lb-rule vip %s:%s add failed\n", IP.String(), ifname)
+			} else {
+				tk.LogIt(tk.LogInfo, "lb-rule vip %s:%s added\n", IP.String(), ifname)
+			}
+			loxinlp.DelNeighNoHook(IP.String(), "")
+		}
+
+		if iface != "" {
+			advCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 			defer cancel()
 			rCh := make(chan int)
-			go utils.NetAdvertiseVIPReqWithCtx(ctx, rCh, IP, iface)
+			go utils.NetAdvertiseVIPReqWithCtx(advCtx, rCh, IP, iface)
 			select {
 			case <-rCh:
 				break
-			case <-ctx.Done():
+			case <-advCtx.Done():
 				tk.LogIt(tk.LogInfo, "lb-rule vip %s - iface %s : GratARP timeout\n", IP.String(), iface)
 			}
 		}
@@ -3504,11 +3517,11 @@ func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool) erro
 	} else if ciState != cmn.CIUnDefStateString {
 		if utils.IsIPHostAddr(IP.String()) {
 			ifname := "lo"
-			ev, _, iface := R.zone.L3.IfaSelectAny(IP, false)
-			if ev == 0 {
-				if tk.IsNetIPv6(IP.String()) {
-					ifname = iface
-				}
+			if tk.IsNetIPv6(IP.String()) {
+				// May come back empty. DelAddrNoHook then asks the kernel which
+				// link actually carries the address, so the delete does not
+				// depend on the same resolution the add did.
+				ifname = R.VipAdvIf(IP, ctx)
 			}
 			if loxinlp.DelAddrNoHook(utils.IPHostCIDRString(IP), ifname) != 0 {
 				tk.LogIt(tk.LogError, "lb-rule vip %s:%s delete failed\n", IP.String(), ifname)
@@ -3573,7 +3586,7 @@ func (R *RuleH) RulesSyncToClusterState(inst, ciStateStr string) {
 			ip = net.ParseIP(vip)
 		}
 		if ip != nil {
-			R.AdvRuleVIP(ip, net.ParseIP(vip), vipElem.inst, vipElem.egr)
+			R.AdvRuleVIP(ip, net.ParseIP(vip), vipElem.inst, vipElem.egr, nil)
 		}
 	}
 }
@@ -3601,9 +3614,9 @@ func (R *RuleH) AddRuleVIP(VIP net.IP, pVIP net.IP, inst string, egress bool) {
 
 	if vipEnt.ref == 1 {
 		if pVIP == nil {
-			R.AdvRuleVIP(VIP, VIP, inst, vipEnt.egr)
+			R.AdvRuleVIP(VIP, VIP, inst, vipEnt.egr, nil)
 		} else {
-			R.AdvRuleVIP(pVIP, VIP, inst, vipEnt.egr)
+			R.AdvRuleVIP(pVIP, VIP, inst, vipEnt.egr, nil)
 		}
 	}
 }
@@ -3622,11 +3635,8 @@ func (R *RuleH) DeleteRuleVIP(VIP net.IP) {
 		}
 		if utils.IsIPHostAddr(xVIP.String()) {
 			ifname := "lo"
-			ev, _, iface := R.zone.L3.IfaSelectAny(xVIP, false)
-			if ev == 0 {
-				if tk.IsNetIPv6(xVIP.String()) {
-					ifname = iface
-				}
+			if tk.IsNetIPv6(xVIP.String()) {
+				ifname = R.VipAdvIf(xVIP, nil)
 			}
 			loxinlp.DelAddrNoHook(utils.IPHostCIDRString(xVIP), ifname)
 			if mh.cloudHook != nil {

--- a/pkg/loxinet/rules.go
+++ b/pkg/loxinet/rules.go
@@ -356,6 +356,11 @@ type vipElem struct {
 	pVIP net.IP
 	inst string
 	egr  bool
+	// advIf - the advertise interface last reported for this VIP, "" for none.
+	// Only ever compared against a fresh resolution so the log can stay quiet
+	// while nothing changes; never read back as an answer.
+	advIf    string
+	advIfSet bool
 }
 
 type allowedSrcElem struct {
@@ -3451,6 +3456,37 @@ func (r *ruleEnt) DP(work DpWorkT) int {
 
 }
 
+// logVipAdvIf - report where a VIP is advertised, only when that changes
+//
+// The sweep comes round about every 40 seconds and almost always resolves to
+// the same interface, so reporting every resolution would bury everything else
+// in the log. eIP is the key the VIP is filed under in vipMap.
+func (R *RuleH) logVipAdvIf(IP net.IP, eIP net.IP, iface string) {
+	if eIP == nil {
+		return
+	}
+
+	vipEnt := R.vipMap[eIP.String()]
+	if vipEnt == nil {
+		return
+	}
+	if vipEnt.advIfSet && vipEnt.advIf == iface {
+		return
+	}
+
+	switch {
+	case iface == "":
+		tk.LogIt(tk.LogInfo, "lb-rule vip %s - no interface to advertise on\n", IP.String())
+	case !vipEnt.advIfSet || vipEnt.advIf == "":
+		tk.LogIt(tk.LogInfo, "lb-rule vip %s - advertising on %s\n", IP.String(), iface)
+	default:
+		tk.LogIt(tk.LogInfo, "lb-rule vip %s - advertising on %s, was %s\n", IP.String(), iface, vipEnt.advIf)
+	}
+
+	vipEnt.advIf = iface
+	vipEnt.advIfSet = true
+}
+
 func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool, ctx *vipAdvCtx) error {
 	if inst == "" {
 		inst = cmn.CIDefault
@@ -3468,6 +3504,7 @@ func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool, ctx 
 			R.zone.L3.IfaDelete(dev, utils.IPHostCIDRString(IP))
 		}
 		iface := R.VipAdvIf(IP, ctx)
+		R.logVipAdvIf(IP, eIP, iface)
 
 		// Binding the address, the cloud hook and the neighbour cleanup do not
 		// depend on having found somewhere to advertise - only the gratuitous
@@ -3516,12 +3553,13 @@ func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool, ctx 
 
 	} else if ciState != cmn.CIUnDefStateString {
 		if utils.IsIPHostAddr(IP.String()) {
+			// IPv4 is always on lo. For IPv6 let DelAddrNoHook ask the kernel
+			// which link carries the address: the delete then does not depend
+			// on the resolution the add used, which may since have changed or
+			// been overridden by configuration.
 			ifname := "lo"
 			if tk.IsNetIPv6(IP.String()) {
-				// May come back empty. DelAddrNoHook then asks the kernel which
-				// link actually carries the address, so the delete does not
-				// depend on the same resolution the add did.
-				ifname = R.VipAdvIf(IP, ctx)
+				ifname = ""
 			}
 			if loxinlp.DelAddrNoHook(utils.IPHostCIDRString(IP), ifname) != 0 {
 				tk.LogIt(tk.LogError, "lb-rule vip %s:%s delete failed\n", IP.String(), ifname)
@@ -3636,7 +3674,7 @@ func (R *RuleH) DeleteRuleVIP(VIP net.IP) {
 		if utils.IsIPHostAddr(xVIP.String()) {
 			ifname := "lo"
 			if tk.IsNetIPv6(xVIP.String()) {
-				ifname = R.VipAdvIf(xVIP, nil)
+				ifname = ""
 			}
 			loxinlp.DelAddrNoHook(utils.IPHostCIDRString(xVIP), ifname)
 			if mh.cloudHook != nil {

--- a/pkg/loxinet/vipadv.go
+++ b/pkg/loxinet/vipadv.go
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2022 NetLOX Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loxinet
+
+import (
+	"net"
+
+	"github.com/loxilb-io/loxilb/pkg/utils"
+	tk "github.com/loxilb-io/loxilib"
+	nl "github.com/vishvananda/netlink"
+)
+
+// vipAdvCtx - state shared by one pass over the VIP map
+//
+// Its only job is to make sure a sweep takes at most one main table dump per
+// address family, and only if some VIP actually gets that far. Nothing here
+// outlives the pass: the interface a VIP is advertised on is resolved fresh
+// every time, so a routing change is picked up on the next sweep instead of
+// being remembered.
+//
+// A nil ctx is valid and means "no pass to share with" - the one-off callers
+// (rule add, cluster state sync, rule delete) go through that path and take a
+// dump of their own if they need one.
+type vipAdvCtx struct {
+	dumped [2]bool
+	routes [2][]nl.Route
+}
+
+func vipAdvFamilyIdx(v6 bool) int {
+	if v6 {
+		return 1
+	}
+	return 0
+}
+
+// dumpMainRoutes - the main table for one address family
+//
+// netlink filters the dump to the main table already, so the VIP's own host
+// route is not in here: that one lives in the local table. The answer is
+// therefore the same before and after the VIP is bound.
+func dumpMainRoutes(v6 bool) []nl.Route {
+	family := nl.FAMILY_V4
+	if v6 {
+		family = nl.FAMILY_V6
+	}
+
+	routes, err := nl.RouteList(nil, family)
+	if err != nil {
+		tk.LogIt(tk.LogError, "vip-adv: main table dump failed: %v\n", err)
+		return nil
+	}
+
+	return routes
+}
+
+// mainRoutes - the shared dump for this pass, taken on first use
+func (c *vipAdvCtx) mainRoutes(v6 bool) []nl.Route {
+	if c == nil {
+		return dumpMainRoutes(v6)
+	}
+
+	idx := vipAdvFamilyIdx(v6)
+	if !c.dumped[idx] {
+		c.routes[idx] = dumpMainRoutes(v6)
+		c.dumped[idx] = true
+	}
+
+	return c.routes[idx]
+}
+
+// vipAdvIfaIf - the port whose subnet contains the VIP
+//
+// For IPv6 this is also where a bound VIP is found, since its /128 makes the
+// port it sits on match. IfaAdd does not mark such an address secondary, so
+// the scan below does not skip it.
+func (R *RuleH) vipAdvIfaIf(IP net.IP) string {
+	v6 := !tk.IsNetIPv4(IP.String())
+
+	for _, ifa := range R.zone.L3.IfaMap {
+		if ifa.Key.Obj == "lo" {
+			continue
+		}
+
+		for _, ifaEnt := range ifa.Ifas {
+			if ifaEnt.Secondary {
+				continue
+			}
+			if v6 != tk.IsNetIPv6(ifaEnt.IfaNet.IP.String()) {
+				continue
+			}
+			if ifaEnt.IfaNet.Contains(IP) {
+				return ifa.Key.Obj
+			}
+		}
+	}
+
+	return ""
+}
+
+// vipAdvTrieIf - the egress port the route trie has for the VIP
+//
+// The trie only ever holds routes over links loxilb registered as ports, and
+// RtAdd keeps rule VIP host routes out of it, so this answer is neither
+// polluted by the VIP's own binding nor by links loxilb does not forward on.
+//
+// A default route match is refused. The trie holds one entry per prefix and
+// the last event to arrive wins, so which of several default routes it ends up
+// with is arbitrary - the loxilb route model carries no metric to break the
+// tie. Falling through to the main table dump gets the kernel's priorities.
+func (R *RuleH) vipAdvTrieIf(IP net.IP) string {
+	var err int
+	var pfx *net.IPNet
+	var tDat tk.TrieData
+
+	if tk.IsNetIPv4(IP.String()) {
+		err, pfx, tDat = R.zone.Rt.Trie4.FindTrie(IP.String())
+	} else {
+		err, pfx, tDat = R.zone.Rt.Trie6.FindTrie(IP.String())
+	}
+
+	if err != 0 || pfx == nil {
+		return ""
+	}
+	if ones, _ := pfx.Mask.Size(); ones == 0 {
+		return ""
+	}
+
+	switch rtn := tDat.(type) {
+	case *Neigh:
+		if rtn != nil && rtn.OifPort != nil {
+			return rtn.OifPort.Name
+		}
+	case *int:
+		if p := R.zone.Ports.PortFindByOSID(*rtn); p != nil {
+			return p.Name
+		}
+	}
+
+	return ""
+}
+
+// vipAdvMainTableIf - longest prefix match over a main table dump
+//
+// Candidates whose egress is not a loxilb port are dropped before the match.
+// loxilb only attaches its datapath to registered ports, so a VIP advertised
+// out of any other link would pull traffic the datapath never sees. The trie
+// steps get this for free; a raw kernel dump does not.
+func (R *RuleH) vipAdvMainTableIf(IP net.IP, ctx *vipAdvCtx) string {
+	v6 := !tk.IsNetIPv4(IP.String())
+	cands := utils.MainTableEgressCands(IP, ctx.mainRoutes(v6), nil)
+
+	best := pickEgressCand(cands, func(ifIndex int) bool {
+		return R.zone.Ports.PortFindByOSID(ifIndex) != nil
+	})
+	if best < 0 {
+		return ""
+	}
+
+	return cands[best].IfName
+}
+
+// pickEgressCand - index of the winning candidate, -1 if none is eligible
+//
+// Longest prefix first, lowest priority to break a tie, and only among links
+// isPort accepts. The port test comes before the match rather than after it, so
+// a more specific route over a link loxilb does not forward on steps aside for
+// the next best one instead of failing the whole resolution.
+func pickEgressCand(cands []utils.EgressCand, isPort func(ifIndex int) bool) int {
+	best := -1
+
+	for i := range cands {
+		if !isPort(cands[i].IfIndex) {
+			continue
+		}
+		if best < 0 ||
+			cands[i].PrefixLen > cands[best].PrefixLen ||
+			(cands[i].PrefixLen == cands[best].PrefixLen && cands[i].Priority < cands[best].Priority) {
+			best = i
+		}
+	}
+
+	return best
+}
+
+// VipAdvIf - the interface a VIP should be advertised on, "" if none resolves
+//
+// Resolution order, stopping at the first answer:
+//
+//  1. IPv6 only, the port carrying the /128. The kernel answers a neighbour
+//     solicitation only on a link that holds the target address, so for IPv6
+//     where the address sits is where it has to be advertised.
+//  2. the route trie's egress port, unless it matched a default route
+//  3. IPv4 only, the port whose subnet contains the VIP
+//  4. longest prefix match over a main table dump
+//
+// Whatever comes back is checked once more against the interface filter, so a
+// link that cannot carry a well formed ARP or NA never reaches a frame builder
+// no matter which step produced it.
+func (R *RuleH) VipAdvIf(IP net.IP, ctx *vipAdvCtx) string {
+	v6 := !tk.IsNetIPv4(IP.String())
+	ifName := ""
+
+	if v6 {
+		ifName = R.vipAdvIfaIf(IP)
+	}
+	if ifName == "" {
+		ifName = R.vipAdvTrieIf(IP)
+	}
+	if ifName == "" && !v6 {
+		ifName = R.vipAdvIfaIf(IP)
+	}
+	if ifName == "" {
+		ifName = R.vipAdvMainTableIf(IP, ctx)
+	}
+
+	if ifName == "" || ifName == "lo" {
+		return ""
+	}
+	if !utils.AdvIfUsableByName(ifName) {
+		tk.LogIt(tk.LogWarning, "vip-adv: %s - %s cannot carry an advertisement\n", IP.String(), ifName)
+		return ""
+	}
+
+	return ifName
+}

--- a/pkg/loxinet/vipadv.go
+++ b/pkg/loxinet/vipadv.go
@@ -18,11 +18,16 @@ package loxinet
 
 import (
 	"net"
+	"sync"
 
+	opts "github.com/loxilb-io/loxilb/options"
 	"github.com/loxilb-io/loxilb/pkg/utils"
 	tk "github.com/loxilb-io/loxilib"
 	nl "github.com/vishvananda/netlink"
 )
+
+// vipAdvDevWarn - the configured device is reported once, not once per sweep
+var vipAdvDevWarn sync.Once
 
 // vipAdvCtx - state shared by one pass over the VIP map
 //
@@ -211,6 +216,10 @@ func pickEgressCand(cands []utils.EgressCand, isPort func(ifIndex int) bool) int
 // link that cannot carry a well formed ARP or NA never reaches a frame builder
 // no matter which step produced it.
 func (R *RuleH) VipAdvIf(IP net.IP, ctx *vipAdvCtx) string {
+	if ifName := R.vipAdvConfIf(); ifName != "" {
+		return ifName
+	}
+
 	v6 := !tk.IsNetIPv4(IP.String())
 	ifName := ""
 
@@ -231,9 +240,40 @@ func (R *RuleH) VipAdvIf(IP net.IP, ctx *vipAdvCtx) string {
 		return ""
 	}
 	if !utils.AdvIfUsableByName(ifName) {
-		tk.LogIt(tk.LogWarning, "vip-adv: %s - %s cannot carry an advertisement\n", IP.String(), ifName)
+		// The caller reports the resolution failure once, on the transition.
+		// This line only says which link was rejected, so it stays at debug.
+		tk.LogIt(tk.LogDebug, "vip-adv: %s - %s cannot carry an advertisement\n", IP.String(), ifName)
 		return ""
 	}
 
 	return ifName
+}
+
+// vipAdvConfIf - the configured advertise interface, "" when there is none to use
+//
+// The escape hatch for the setups automatic resolution cannot get right:
+// multi-homed hosts where the client facing link is not the one the routing
+// table points at, ECMP, and policy routing. A configured device that loxilb
+// has not registered as a port is refused for the same reason step 4 refuses
+// one, and resolution carries on as if nothing were configured.
+func (R *RuleH) vipAdvConfIf() string {
+	dev := opts.Opts.VIPAdvDev
+	if dev == "" {
+		return ""
+	}
+
+	if R.zone.Ports.PortFindByName(dev) == nil {
+		vipAdvDevWarn.Do(func() {
+			tk.LogIt(tk.LogError, "vip-adv: configured dev %s is not a loxilb port, ignored\n", dev)
+		})
+		return ""
+	}
+	if !utils.AdvIfUsableByName(dev) {
+		vipAdvDevWarn.Do(func() {
+			tk.LogIt(tk.LogError, "vip-adv: configured dev %s cannot carry an advertisement, ignored\n", dev)
+		})
+		return ""
+	}
+
+	return dev
 }

--- a/pkg/loxinet/vipadv_test.go
+++ b/pkg/loxinet/vipadv_test.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 NetLOX Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loxinet
+
+import (
+	"testing"
+
+	"github.com/loxilb-io/loxilb/pkg/utils"
+)
+
+// portsAre - an isPort test that accepts the listed link indexes
+func portsAre(indexes ...int) func(int) bool {
+	set := make(map[int]bool, len(indexes))
+	for _, i := range indexes {
+		set[i] = true
+	}
+	return func(ifIndex int) bool { return set[ifIndex] }
+}
+
+func TestPickEgressCand(t *testing.T) {
+	tests := []struct {
+		name   string
+		cands  []utils.EgressCand
+		isPort func(int) bool
+		want   int
+	}{
+		{
+			name:   "no candidates",
+			cands:  nil,
+			isPort: portsAre(2, 3),
+			want:   -1,
+		},
+		{
+			name: "longest prefix wins",
+			cands: []utils.EgressCand{
+				{PrefixLen: 0, Priority: 0, IfIndex: 2},
+				{PrefixLen: 24, Priority: 100, IfIndex: 3},
+				{PrefixLen: 8, Priority: 0, IfIndex: 3},
+			},
+			isPort: portsAre(2, 3),
+			want:   1,
+		},
+		{
+			name: "lowest priority breaks a tie",
+			cands: []utils.EgressCand{
+				{PrefixLen: 24, Priority: 200, IfIndex: 2},
+				{PrefixLen: 24, Priority: 50, IfIndex: 3},
+				{PrefixLen: 24, Priority: 100, IfIndex: 2},
+			},
+			isPort: portsAre(2, 3),
+			want:   1,
+		},
+		{
+			name: "first of an exact tie wins",
+			cands: []utils.EgressCand{
+				{PrefixLen: 16, Priority: 10, IfIndex: 2},
+				{PrefixLen: 16, Priority: 10, IfIndex: 3},
+			},
+			isPort: portsAre(2, 3),
+			want:   0,
+		},
+		{
+			name: "a non port loses to a shorter prefix",
+			cands: []utils.EgressCand{
+				{PrefixLen: 8, Priority: 0, IfIndex: 2},
+				{PrefixLen: 24, Priority: 0, IfIndex: 9},
+			},
+			isPort: portsAre(2, 3),
+			want:   0,
+		},
+		{
+			name: "every candidate is a non port",
+			cands: []utils.EgressCand{
+				{PrefixLen: 24, Priority: 0, IfIndex: 9},
+				{PrefixLen: 0, Priority: 0, IfIndex: 8},
+			},
+			isPort: portsAre(2, 3),
+			want:   -1,
+		},
+		{
+			name: "default route is a valid last resort",
+			cands: []utils.EgressCand{
+				{PrefixLen: 0, Priority: 100, IfIndex: 2},
+			},
+			isPort: portsAre(2),
+			want:   0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pickEgressCand(tc.cands, tc.isPort); got != tc.want {
+				t.Fatalf("pickEgressCand = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/loxinet/vipadv_test.go
+++ b/pkg/loxinet/vipadv_test.go
@@ -17,6 +17,7 @@
 package loxinet
 
 import (
+	"net"
 	"testing"
 
 	"github.com/loxilb-io/loxilb/pkg/utils"
@@ -108,4 +109,46 @@ func TestPickEgressCand(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLogVipAdvIfTransitions - the reporter must stay quiet while a VIP keeps
+// resolving to the same interface, and speak up on every change including the
+// first resolution and the first failure. tk.LogIt is a no-op without a logger,
+// so this checks the state it keeps rather than the lines it writes.
+func TestLogVipAdvIfTransitions(t *testing.T) {
+	const key = "20.20.20.1"
+	ip := net.ParseIP(key)
+
+	R := &RuleH{vipMap: map[string]*vipElem{key: {ref: 1}}}
+	ent := R.vipMap[key]
+
+	steps := []struct {
+		iface  string
+		report bool
+	}{
+		{"", true},      // first pass, nothing resolves
+		{"", false},     // still nothing, stay quiet
+		{"eth0", true},  // resolved at last
+		{"eth0", false}, // unchanged
+		{"eth1", true},  // routing moved
+		{"", true},      // link went away
+		{"eth1", true},  // and came back
+	}
+
+	for i, st := range steps {
+		beforeIf, beforeSet := ent.advIf, ent.advIfSet
+		R.logVipAdvIf(ip, ip, st.iface)
+
+		reported := ent.advIf != beforeIf || ent.advIfSet != beforeSet
+		if reported != st.report {
+			t.Fatalf("step %d (%q): reported %v, want %v", i, st.iface, reported, st.report)
+		}
+		if ent.advIf != st.iface || !ent.advIfSet {
+			t.Fatalf("step %d (%q): state %q set %v", i, st.iface, ent.advIf, ent.advIfSet)
+		}
+	}
+
+	// A VIP that is not in the map must not be tracked or panic.
+	R.logVipAdvIf(ip, net.ParseIP("20.20.20.2"), "eth0")
+	R.logVipAdvIf(ip, nil, "eth0")
 }

--- a/pkg/utils/net.go
+++ b/pkg/utils/net.go
@@ -62,6 +62,13 @@ func NetAdvertiseVI64Req(targetIP net.IP, ifName string) (int, error) {
 	if err != nil {
 		return -1, errors.New("intfv6-err")
 	}
+	// newNeighborAdvertisementPayload copies into a fixed size buffer, so a link
+	// without a six byte MAC puts an all-zero target link-layer address option
+	// on the wire. That NA is well formed, and a receiver acting on it maps the
+	// VIP to 00:00:00:00:00:00.
+	if len(ifi.HardwareAddr) != 6 {
+		return -1, errors.New("intfv6-mac-err")
+	}
 
 	srcIP := net.IPv6linklocalallnodes
 	dstIP := net.IPv6linklocalallnodes
@@ -262,8 +269,144 @@ func IsIPHostNetAddr(ip net.IP) bool {
 	return false
 }
 
+// EgressCand - a candidate egress interface for advertising a VIP, taken from
+// a single main table route that covers it
+type EgressCand struct {
+	// PrefixLen - prefix length of the matching route, longest match wins
+	PrefixLen int
+	// Priority - route metric, lowest wins between equal prefix lengths
+	Priority int
+	// IfIndex - OS index of the egress link
+	IfIndex int
+	// IfName - name of the egress link
+	IfName string
+}
+
+// IfLookup - resolves an OS link index to an interface, so tests can supply
+// their own links instead of whatever the host happens to have
+type IfLookup func(index int) (*net.Interface, error)
+
+// AdvIfUsable - can a gratuitous ARP or an unsolicited NA go out of this link
+//
+// The frame builders copy HardwareAddr into the payload, so a link without a
+// six byte MAC yields either a short ARP frame or an NA whose target
+// link-layer address option is all zeros. Go leaves HardwareAddr empty when
+// IFLA_ADDRESS is all zeros, which is the case for lo and for L3-only devices,
+// and loxilb registers such links as ports all the same. A point-to-point link
+// has no L2 neighbours to tell.
+func AdvIfUsable(ifi *net.Interface) bool {
+	if ifi == nil {
+		return false
+	}
+	if ifi.Flags&net.FlagUp == 0 {
+		return false
+	}
+	if ifi.Flags&net.FlagPointToPoint != 0 {
+		return false
+	}
+	return len(ifi.HardwareAddr) == 6
+}
+
+// AdvIfUsableByName - AdvIfUsable for a link named at runtime
+func AdvIfUsableByName(ifName string) bool {
+	if ifName == "" || ifName == "lo" {
+		return false
+	}
+	ifi, err := net.InterfaceByName(ifName)
+	if err != nil {
+		return false
+	}
+	return AdvIfUsable(ifi)
+}
+
+// routeCovers - does rt cover dst, and at what prefix length
+//
+// netlink leaves Dst nil for a default route, so its family comes from the
+// message instead.
+func routeCovers(rt *nlp.Route, dst net.IP, v6 bool) (int, bool) {
+	if rt.Dst == nil {
+		if (rt.Family == unix.AF_INET6) != v6 {
+			return 0, false
+		}
+		return 0, true
+	}
+
+	if (rt.Dst.IP.To4() == nil) != v6 {
+		return 0, false
+	}
+	if !rt.Dst.Contains(dst) {
+		return 0, false
+	}
+
+	ones, _ := rt.Dst.Mask.Size()
+	return ones, true
+}
+
+// MainTableEgressCands - egress candidates for dst out of a main table route dump
+//
+// Every candidate returned covers dst, comes from a unicast route and has an
+// egress link that passes AdvIfUsable. Other route types are dropped because
+// blackhole, unreachable, prohibit and throw carry no RTA_OIF, so their
+// LinkIndex is zero. Multipath routes report their first nexthop, which is not
+// necessarily the one the kernel's per-flow hash picks.
+//
+// The result is deliberately unordered and unfiltered beyond that: the caller
+// knows which links are loxilb ports and must drop the rest before picking the
+// longest prefix, and the lowest Priority between equal prefixes. lookup
+// defaults to net.InterfaceByIndex.
+func MainTableEgressCands(dst net.IP, routes []nlp.Route, lookup IfLookup) []EgressCand {
+	if dst == nil {
+		return nil
+	}
+	if lookup == nil {
+		lookup = net.InterfaceByIndex
+	}
+
+	v6 := dst.To4() == nil
+	cands := make([]EgressCand, 0, 4)
+
+	for i := range routes {
+		rt := &routes[i]
+
+		if rt.Type != unix.RTN_UNICAST {
+			continue
+		}
+
+		prefixLen, ok := routeCovers(rt, dst, v6)
+		if !ok {
+			continue
+		}
+
+		ifIndex := rt.LinkIndex
+		if len(rt.MultiPath) > 0 {
+			ifIndex = rt.MultiPath[0].LinkIndex
+		}
+		if ifIndex <= 0 {
+			continue
+		}
+
+		ifi, err := lookup(ifIndex)
+		if err != nil || !AdvIfUsable(ifi) {
+			continue
+		}
+
+		cands = append(cands, EgressCand{
+			PrefixLen: prefixLen,
+			Priority:  rt.Priority,
+			IfIndex:   ifIndex,
+			IfName:    ifi.Name,
+		})
+	}
+
+	return cands
+}
+
 // NetAdvertiseVIP4Req - sends a gratuitous arp reply given the DIP, SIP and interface name
 func NetAdvertiseVIP4Req(AdvIP net.IP, ifName string) (int, error) {
+	if AdvIP == nil || ifName == "" || ifName == "lo" {
+		return -1, errors.New("invalid parameters")
+	}
+
 	bcAddr := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_DGRAM, int(tk.Htons(syscall.ETH_P_ARP)))
 	if err != nil {
@@ -278,6 +421,12 @@ func NetAdvertiseVIP4Req(AdvIP net.IP, ifName string) (int, error) {
 	ifi, err := net.InterfaceByName(ifName)
 	if err != nil {
 		return -1, errors.New("intf-err")
+	}
+	// The frame below writes HardwareAddr as the sender hardware address without
+	// padding it, so anything but six bytes puts a short, malformed ARP on the
+	// wire. Go leaves HardwareAddr empty when IFLA_ADDRESS is all zeros.
+	if len(ifi.HardwareAddr) != 6 {
+		return -1, errors.New("intf-mac-err")
 	}
 
 	ll := syscall.SockaddrLinklayer{
@@ -417,6 +566,12 @@ func SendArpReq(AdvIP net.IP, ifName string) (int, error) {
 	ifi, err := net.InterfaceByName(ifName)
 	if err != nil {
 		return -1, errors.New("intf-err")
+	}
+	// The frame below writes HardwareAddr as the sender hardware address without
+	// padding it, so anything but six bytes puts a short, malformed ARP on the
+	// wire. Go leaves HardwareAddr empty when IFLA_ADDRESS is all zeros.
+	if len(ifi.HardwareAddr) != 6 {
+		return -1, errors.New("intf-mac-err")
 	}
 
 	ll := syscall.SockaddrLinklayer{

--- a/pkg/utils/net_test.go
+++ b/pkg/utils/net_test.go
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2022 NetLOX Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	nlp "github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+var testMac = net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}
+
+// testLinks - the links the fake lookup below knows about
+//
+//	2 eth0  usable
+//	3 eth1  usable
+//	4 down  admin down
+//	5 l3    no MAC, as Go reports an all-zero IFLA_ADDRESS
+//	6 tun0  point to point
+var testLinks = map[int]*net.Interface{
+	2: {Index: 2, Name: "eth0", Flags: net.FlagUp, HardwareAddr: testMac},
+	3: {Index: 3, Name: "eth1", Flags: net.FlagUp, HardwareAddr: testMac},
+	4: {Index: 4, Name: "down", HardwareAddr: testMac},
+	5: {Index: 5, Name: "l3", Flags: net.FlagUp},
+	6: {Index: 6, Name: "tun0", Flags: net.FlagUp | net.FlagPointToPoint, HardwareAddr: testMac},
+}
+
+func testLookup(index int) (*net.Interface, error) {
+	if ifi, ok := testLinks[index]; ok {
+		return ifi, nil
+	}
+	return nil, fmt.Errorf("no such link %d", index)
+}
+
+func mustCIDR(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("parse %s: %v", cidr, err)
+	}
+	return n
+}
+
+func TestAdvIfUsable(t *testing.T) {
+	tests := []struct {
+		name string
+		ifi  *net.Interface
+		want bool
+	}{
+		{"nil", nil, false},
+		{"up with mac", testLinks[2], true},
+		{"admin down", testLinks[4], false},
+		{"no mac", testLinks[5], false},
+		{"point to point", testLinks[6], false},
+		{"short mac", &net.Interface{Name: "x", Flags: net.FlagUp, HardwareAddr: net.HardwareAddr{1, 2, 3}}, false},
+		{"infiniband mac", &net.Interface{Name: "ib0", Flags: net.FlagUp, HardwareAddr: make(net.HardwareAddr, 20)}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AdvIfUsable(tc.ifi); got != tc.want {
+				t.Fatalf("AdvIfUsable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMainTableEgressCandsIPv4(t *testing.T) {
+	dst := net.ParseIP("10.1.2.3")
+
+	routes := []nlp.Route{
+		// default route, netlink leaves Dst nil so only Family says v4
+		{Type: unix.RTN_UNICAST, Family: unix.AF_INET, LinkIndex: 2, Priority: 100},
+		// covering route, more specific
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "10.0.0.0/8"), LinkIndex: 3, Priority: 0},
+		// multipath: the egress is the first nexthop, LinkIndex is zero
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "10.1.0.0/16"), Priority: 50,
+			MultiPath: []*nlp.NexthopInfo{{LinkIndex: 3}, {LinkIndex: 2}}},
+		// blackhole and friends carry no RTA_OIF
+		{Type: unix.RTN_BLACKHOLE, Dst: mustCIDR(t, "10.1.2.0/24")},
+		{Type: unix.RTN_UNREACHABLE, Dst: mustCIDR(t, "10.1.2.0/24")},
+		// does not cover dst
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "192.168.0.0/16"), LinkIndex: 3},
+		// covering, but the egress link is unusable
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "10.1.2.0/24"), LinkIndex: 4},
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "10.1.2.0/24"), LinkIndex: 5},
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "10.1.2.0/24"), LinkIndex: 6},
+		// covering, but the link is gone by the time we look it up
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "10.1.2.0/24"), LinkIndex: 99},
+		// wrong family
+		{Type: unix.RTN_UNICAST, Family: unix.AF_INET6, LinkIndex: 2},
+	}
+
+	want := []EgressCand{
+		{PrefixLen: 0, Priority: 100, IfIndex: 2, IfName: "eth0"},
+		{PrefixLen: 8, Priority: 0, IfIndex: 3, IfName: "eth1"},
+		{PrefixLen: 16, Priority: 50, IfIndex: 3, IfName: "eth1"},
+	}
+
+	got := MainTableEgressCands(dst, routes, testLookup)
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates %v, want %d", len(got), got, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("candidate %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMainTableEgressCandsIPv6(t *testing.T) {
+	dst := net.ParseIP("2001:db8::1")
+
+	routes := []nlp.Route{
+		{Type: unix.RTN_UNICAST, Family: unix.AF_INET6, LinkIndex: 2, Priority: 1024},
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "2001:db8::/32"), LinkIndex: 3},
+		// v4 default route must not answer for a v6 VIP
+		{Type: unix.RTN_UNICAST, Family: unix.AF_INET, LinkIndex: 3},
+		{Type: unix.RTN_UNICAST, Dst: mustCIDR(t, "2001:db9::/32"), LinkIndex: 3},
+	}
+
+	want := []EgressCand{
+		{PrefixLen: 0, Priority: 1024, IfIndex: 2, IfName: "eth0"},
+		{PrefixLen: 32, Priority: 0, IfIndex: 3, IfName: "eth1"},
+	}
+
+	got := MainTableEgressCands(dst, routes, testLookup)
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates %v, want %d", len(got), got, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("candidate %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMainTableEgressCandsNoDst(t *testing.T) {
+	routes := []nlp.Route{{Type: unix.RTN_UNICAST, Family: unix.AF_INET, LinkIndex: 2}}
+	if got := MainTableEgressCands(nil, routes, testLookup); got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}
+
+// TestAdvertiseReqParamGuards - neither frame builder should reach a socket
+// with parameters it cannot build a frame from. The MAC length rule they also
+// enforce is covered by TestAdvIfUsable; exercising it here would need a real
+// MAC-less link.
+func TestAdvertiseReqParamGuards(t *testing.T) {
+	v4 := net.ParseIP("20.20.20.1")
+	v6 := net.ParseIP("2001:db8::1")
+
+	tests := []struct {
+		name string
+		call func() (int, error)
+	}{
+		{"v4 nil ip", func() (int, error) { return NetAdvertiseVIP4Req(nil, "eth0") }},
+		{"v4 empty ifname", func() (int, error) { return NetAdvertiseVIP4Req(v4, "") }},
+		{"v4 loopback", func() (int, error) { return NetAdvertiseVIP4Req(v4, "lo") }},
+		{"v6 nil ip", func() (int, error) { return NetAdvertiseVI64Req(nil, "eth0") }},
+		{"v6 empty ifname", func() (int, error) { return NetAdvertiseVI64Req(v6, "") }},
+		{"v6 loopback", func() (int, error) { return NetAdvertiseVI64Req(v6, "lo") }},
+		{"v6 with a v4 address", func() (int, error) { return NetAdvertiseVI64Req(v4, "eth0") }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ret, err := tc.call()
+			if ret == 0 || err == nil {
+				t.Fatalf("accepted bad parameters: ret %d err %v", ret, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Supersedes #1121. Same problem, different resolution. Keeps that PR's `NetAdvertiseVIP4Req` input guard.

### The problem

`AdvRuleVIP` asked `IfaSelectAny(IP, false)` for the interface to advertise a VIP on, and when that failed it skipped everything: no gratuitous ARP, but also no kernel bind and no cloud hook. `IfaSelectAny` answers from the subnets loxilb already knows about, so a VIP routed from outside every local subnet never resolved and was never bound at all.

### Why not a `RouteGet` fallback

#1121 filled the gap with `RouteGet` plus a default-route fallback. Once the VIP is bound to `lo`, `RouteGet(VIP)` returns `local ... dev lo`, so from the second sweep onwards that branch is dead and every re-advertisement goes through the fallback. The fallback in turn has no route-type filter (`blackhole` and friends carry no `RTA_OIF`, so `LinkIndex` is 0), does not handle ECMP (`MultiPath` instead of `LinkIndex`), does not check that the egress can carry a frame, and leaves the delete path resolving separately from the add path.

To be clear about what this PR does not fix: on a multi-homed host the default route's egress still is not necessarily where the VIP's clients are. No automatic rule can know that, which is why there is an explicit option.

### Resolution order

Per sweep, nothing cached:

1. **IPv6 only** — the port carrying the `/128`. The kernel answers a neighbour solicitation only on a link that holds the target address, so for IPv6 where the address sits is where it must be advertised.
2. **The route trie's egress port.** `RtAdd` keeps rule VIP host routes out of the trie, so it is not polluted by the VIP's own binding, and the trie only holds routes over registered ports.
3. **IPv4 only** — the port whose subnet contains the VIP.
4. **Longest prefix match over a main table dump.**

A default route match in step 2 is refused and left to step 4. The trie holds one entry per prefix and the last event wins, so with more than one default route its answer is arbitrary — the loxilb route model carries no metric to break the tie. Step 4 sees the kernel's priorities.

Step 4 drops candidates whose egress is not a loxilb port, before the match rather than after, so a more specific route over a link loxilb does not forward on steps aside for the next best one. The datapath is attached per port: a VIP advertised anywhere else pulls traffic that never reaches the load balancer. Steps 1 to 3 get this for free.

`--vip-adv-dev` skips all of it. It is the escape hatch for multi-homed hosts, ECMP and policy routing. A device that is not a loxilb port, or cannot carry a frame, is reported once and ignored rather than refused outright, so a typo does not leave VIPs unadvertised.

### Also in here

- **The bind gate and the advertise gate are separate now.** Binding, the cloud hook and the neighbour cleanup no longer depend on having found somewhere to advertise, so an unresolved VIP is still bound and still serves. IPv6 is the exception, since its bind target is the port that failed to resolve.
- **Master, backup and `DeleteRuleVIP` share the resolver.** Deletes go further and do not consult it at all: IPv4 is always on `lo`, and for IPv6 an empty interface name makes `DelAddrNoHook` ask the kernel which link carries the address, the way `DelNeighNoHook` already does for neighbours. A delete no longer has to agree with whatever the add resolved.
- **Both frame builders require a six-byte MAC.** They copy `HardwareAddr` into the frame without padding, and Go leaves it empty when `IFLA_ADDRESS` is all zeros — which `ModLink` registers as a port regardless, since its MAC copy is length conditional. The v4 builder would send an ARP six bytes short; `newNeighborAdvertisementPayload` copies into a fixed size buffer, so the v6 one stays well formed and tells the receiver to map the VIP to `00:00:00:00:00:00`. `SendArpReq` builds its request the same way and gets the same check.
- **The advertise interface is logged only when it changes.** The sweep runs about every 40 seconds and almost always resolves to the same interface.

### Layering

`pkg/utils` returns candidates; `pkg/loxinet` takes the dump, drops non-ports and picks. The port test cannot live in `pkg/utils`: `api/loxinlp` imports it, so the reverse is a cycle, and `PortFindByOSID` is in `pkg/loxinet`.

### Testing

Unit tests cover candidate extraction from a route dump, the interface filter, the winner selection, the frame builder guards and the change-only logging. `TestLoxinet` still passes.

`cicd/ha1-vipadv` covers it end to end, in both modes, with the README next to it. Results on a local run:

```
VIPADV Phase-1 vip4 bound on llb2 [OK]          # routed VIP on lo
VIPADV Phase-1 vip6 on llb2 vlan11 [OK]
VIPADV Phase-1 resolved v4 'vlan11' v6 'vlan11' on llb2
VIPADV Phase-1 garp seen on r1 vlan11 [OK]
VIPADV Phase-1 garp repeated on a later sweep [OK]
VIPADV HA flip [OK]
VIPADV Phase-2 vip4 bound on llb1 [OK]          # both VIPs released by the demoted master
VIPADV Phase-2 vip6 on llb1 vlan11 [OK]
```

In automatic mode the same topology resolves the IPv4 VIP to the container's default route rather than the VLAN, which is correct for the routing table those load balancers have, and the VIP is still bound on `lo` — the case the gate split exists for.

Note that `cicd/ha1`, which this is derived from, is not referenced by any workflow, so neither is this one until someone adds it.
