### PR TITLE
loxinet: repeat the VIP advertisement after a MASTER transition

### DIFF
--- a/cicd/ha1-vipadv/README.md
+++ b/cicd/ha1-vipadv/README.md
@@ -40,11 +40,21 @@ Before and after an HA transition:
 - which interface each VIP resolved to, read back from the load balancer's log
 - a gratuitous ARP for the IPv4 VIP reaches `r1` on the VLAN, and reaches it
   again on a later sweep
+- the promotion is advertised more than once: at least three gratuitous ARPs
+  for the IPv4 VIP reach `r1` in the seconds after the flip
 
 The repeat matters. A resolver that asks the kernel for a route to the VIP gets
 `local ... dev lo` back once the VIP is bound, so it works on the first pass and
 goes wrong on every one after it. The VIP sweep runs roughly every 40 seconds,
 so the second capture window is what a first pass alone would not catch.
+
+The burst matters for a different reason. The transition sends one gratuitous
+ARP, and the next is the sweep's, up to 30 seconds later. If that one frame is
+lost, every neighbour keeps forwarding to the old master until the sweep. So
+loxilb repeats it `--vip-adv-repeat` times (default 3), a second apart, the way
+keepalived does with `garp_master_repeat`. The check counts frames in an eight
+second window around the flip: the sweep can add one, so two proves nothing,
+and three is the least that shows a repeat happened.
 
 ## Modes
 

--- a/cicd/ha1-vipadv/validation.sh
+++ b/cicd/ha1-vipadv/validation.sh
@@ -81,6 +81,34 @@ garp_seen() {
     [[ -n "$out" ]]
 }
 
+# garp_capture_start <seconds> <file> - collect gratuitous ARPs for the v4 VIP
+# on r1's VLAN 11 into file, in the background, for the given time
+garp_capture_start() {
+    $hexec r1 timeout $1 tcpdump -l -n -i vlan11 \
+          'arp and arp[14:4] = 0x14141401' > $2 2>/dev/null &
+    # tcpdump takes a moment to attach; the flip must not outrun it.
+    sleep 1
+}
+
+# check_garp_burst <capture file> <phase> - the promotion was advertised more
+# than once
+#
+# The transition sends one gratuitous ARP and --vip-adv-repeat (default 3)
+# more follow a second apart, so the window holds four. The periodic sweep may
+# add one of its own, so a count of two proves nothing: transition plus sweep
+# gets there without any repeat. Three does, with one frame to spare for loss.
+check_garp_burst() {
+    local file=$1 phase=$2
+    local n=$(grep -c . $file 2>/dev/null)
+
+    if [[ $n -ge 3 ]]; then
+        echo "VIPADV $phase garp repeated on promotion ($n in window) [OK]"
+        return 0
+    fi
+    echo "VIPADV $phase garp not repeated on promotion ($n in window, want >= 3) [FAILED]"
+    return 1
+}
+
 check_vip_adv() {
     local master=$1 backup=$2 phase=$3
     local rc=0
@@ -164,6 +192,17 @@ echo "Master:$master Backup:$backup"
 
 check_vip_adv $master $backup Phase-1 || code=1
 
+# The burst check needs the capture running before the promotion lands. It is
+# a tcpdump on the host like garp_seen, with the same reasons to skip.
+burst_check="yes"
+if [[ -z "$advdev" ]] || ! command -v tcpdump >/dev/null 2>&1; then
+    burst_check="no"
+fi
+burst_file=$(mktemp)
+if [[ $burst_check == "yes" ]]; then
+    garp_capture_start 8 $burst_file
+fi
+
 echo "VIPADV flipping HA state through the API"
 set_ci_state $master BACKUP
 set_ci_state $backup MASTER
@@ -179,6 +218,14 @@ else
     echo "VIPADV HA flip [FAILED]"
     exit 1
 fi
+
+if [[ $burst_check == "yes" ]]; then
+    wait
+    check_garp_burst $burst_file Phase-2 || code=1
+else
+    echo "VIPADV Phase-2 garp burst check skipped"
+fi
+rm -f $burst_file
 
 # The demoted master has to give both VIPs up, and the promoted one take them.
 # One sweep is about 40 seconds; allow two.

--- a/options/options.go
+++ b/options/options.go
@@ -49,6 +49,7 @@ var Opts struct {
 	WhiteList            string         `long:"whitelist" description:"Regex string of whitelisted interface(experimental)" default:"none"`
 	ClusterInterface     string         `long:"clusterinterface" description:"cluster interface for egress HA" default:""`
 	VIPAdvDev            string         `long:"vip-adv-dev" description:"interface to advertise LB rule VIPs on, overrides automatic resolution" default:""`
+	VIPAdvRepeat         int            `long:"vip-adv-repeat" description:"gratuitous ARP/NA repeats after becoming MASTER, one a second, 0 to disable" default:"3"`
 	UserServiceEnable    bool           `long:"userservice" description:"Enable user service for loxilb"`
 	DatabaseHost         string         `long:"databasehost" description:"Database host" default:"127.0.0.1"`
 	DatabasePort         int            `long:"databaseport" description:"Database port" default:"3306"`

--- a/pkg/loxinet/rules.go
+++ b/pkg/loxinet/rules.go
@@ -94,6 +94,7 @@ const (
 	EndPointCheckerDuration    = 2          // Duration at which ep-helpers will run
 	MaxEndPointSweeps          = 20         // Maximum end-point sweeps per round
 	VIPSweepDuration           = 30         // Duration of periodic VIP maintenance
+	VIPAdvRepeatInterval       = 1          // Seconds between the repeated advertisements after a MASTER transition
 	DefaultPersistTimeOut      = 10800      // Default persistent LB session timeout
 	NatFwMark                  = 0x80000000 // NAT Marker
 	SrcChkFwMark               = 0x40000000 // Src check Marker
@@ -386,6 +387,7 @@ type RuleH struct {
 	rootCAPool *x509.CertPool
 	tlsCert    tls.Certificate
 	vipST      time.Time
+	vipAdvRep  vipAdvBurstSched
 }
 
 // RulesInit - initialize the Rules subsystem
@@ -3487,6 +3489,22 @@ func (R *RuleH) logVipAdvIf(IP net.IP, eIP net.IP, iface string) {
 	vipEnt.advIfSet = true
 }
 
+// vipAdvSend - one gratuitous ARP or NA for IP out of iface
+//
+// The reply channel is buffered so a sender that finishes after the deadline
+// has somewhere to put its answer instead of blocking forever.
+func vipAdvSend(IP net.IP, iface string) {
+	advCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	rCh := make(chan int, 1)
+	go utils.NetAdvertiseVIPReqWithCtx(advCtx, rCh, IP, iface)
+	select {
+	case <-rCh:
+	case <-advCtx.Done():
+		tk.LogIt(tk.LogInfo, "lb-rule vip %s - iface %s : GratARP timeout\n", IP.String(), iface)
+	}
+}
+
 func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool, ctx *vipAdvCtx) error {
 	if inst == "" {
 		inst = cmn.CIDefault
@@ -3535,16 +3553,7 @@ func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool, ctx 
 		}
 
 		if iface != "" {
-			advCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
-			defer cancel()
-			rCh := make(chan int)
-			go utils.NetAdvertiseVIPReqWithCtx(advCtx, rCh, IP, iface)
-			select {
-			case <-rCh:
-				break
-			case <-advCtx.Done():
-				tk.LogIt(tk.LogInfo, "lb-rule vip %s - iface %s : GratARP timeout\n", IP.String(), iface)
-			}
+			vipAdvSend(IP, iface)
 		}
 
 		if egress {
@@ -3627,6 +3636,8 @@ func (R *RuleH) RulesSyncToClusterState(inst, ciStateStr string) {
 			R.AdvRuleVIP(ip, net.ParseIP(vip), vipElem.inst, vipElem.egr, nil)
 		}
 	}
+
+	R.vipAdvBurstOnState(inst, ciStateStr)
 }
 
 func (r *ruleEnt) RuleVIP2PrivIP() net.IP {

--- a/pkg/loxinet/rules.go
+++ b/pkg/loxinet/rules.go
@@ -3601,6 +3601,12 @@ func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool, ctx 
 	return nil
 }
 
+// RulesSyncToClusterState - bring rules, VIPs and firewall entries in line
+// with a cluster state change
+//
+// Always started with go from CIStateUpdate, one goroutine per transition,
+// and runs without mh.mtx. It must not be called synchronously while mh.mtx
+// is held: vipAdvBurstOnState takes that lock itself.
 func (R *RuleH) RulesSyncToClusterState(inst, ciStateStr string) {
 
 	// For Cloud integrations, certain operations are performed only on default instance state changes
@@ -3637,7 +3643,7 @@ func (R *RuleH) RulesSyncToClusterState(inst, ciStateStr string) {
 		}
 	}
 
-	R.vipAdvBurstOnState(inst, ciStateStr)
+	R.vipAdvBurstOnState(inst)
 }
 
 func (r *ruleEnt) RuleVIP2PrivIP() net.IP {

--- a/pkg/loxinet/vipadv.go
+++ b/pkg/loxinet/vipadv.go
@@ -288,10 +288,11 @@ type vipAdvBurst struct {
 
 // vipAdvBurstSched - at most one advertisement burst per cluster instance
 //
-// A burst belongs to the transition that started it. The next transition of
-// the same instance, whichever way it goes, replaces it: a promotion starts a
-// fresh burst, a demotion just stops the old one, so a master that steps down
-// mid-burst does not keep claiming the VIPs for the peer that took them.
+// A burst belongs to the most recently observed state of its instance, not to
+// the transition that happened to start it. Each observation replaces what is
+// running: master starts a fresh burst, anything else just stops the old one,
+// so a master that steps down mid-burst does not keep claiming the VIPs for
+// the peer that took them.
 type vipAdvBurstSched struct {
 	mx     sync.Mutex
 	active map[string]*vipAdvBurst
@@ -339,23 +340,36 @@ type vipAdvTarget struct {
 	iface string
 }
 
-// vipAdvBurstOnState - repeat the advertisement after a MASTER transition
+// vipAdvBurstOnState - repeat the advertisement while the instance is master
 //
-// The transition sends one gratuitous ARP or NA per VIP, and the next one is
-// the sweep's, up to VIPSweepDuration later. One frame is easy to lose - the
-// link may still be coming up, the switch may still be learning - and until
-// the sweep every neighbour keeps its stale entry and forwards to the old
-// master. So send a few more, VIPAdvRepeatInterval apart, the way keepalived
-// does with garp_master_repeat. Rule adds while already master are not
-// repeated: there is no stale entry to overwrite, the first ARP request
-// resolves the VIP on its own.
+// A promotion sends one gratuitous ARP or NA per VIP, and the next one is the
+// sweep's, up to VIPSweepDuration later. One frame is easy to lose - the link
+// may still be coming up, the switch may still be learning - and until the
+// sweep every neighbour keeps its stale entry and forwards to the old master.
+// So send a few more, VIPAdvRepeatInterval apart, the way keepalived does
+// with garp_master_repeat. Rule adds while already master are not repeated:
+// there is no stale entry to overwrite, the first ARP request resolves the
+// VIP on its own.
 //
-// Whatever the new state, a burst still running for the instance is dropped
-// first. The repeats are advertisements only: the bind, cloud hook and
-// neighbour cleanup happened on the transition and are not redone.
-func (R *RuleH) vipAdvBurstOnState(inst, ciStateStr string) {
+// The decision is taken on the state as it is now, not on the transition that
+// got us here. The cluster sync runs as one goroutine per transition with no
+// ordering between them, so a late BACKUP sync must not cancel the burst a
+// newer MASTER sync started. The read and the arm sit under one exclusive
+// lock: state changes happen under the same lock, so whichever sync runs
+// last acts on the true state at that moment. This nests s.mx inside mh.mtx;
+// nothing takes them the other way round - the burst goroutine takes mh.mtx
+// only from vipAdvBurstTargets, after run has been entered, and its cleanup
+// takes s.mx only after run has returned.
+//
+// The repeats are advertisements only: the bind, cloud hook and neighbour
+// cleanup happened on the transition and are not redone.
+func (R *RuleH) vipAdvBurstOnState(inst string) {
+	mh.mtx.Lock()
+	defer mh.mtx.Unlock()
+
+	ciState, _ := mh.has.CIStateGetInst(inst)
 	repeat := opts.Opts.VIPAdvRepeat
-	if ciStateStr != cmn.CIMasterStateString || repeat <= 0 {
+	if ciState != cmn.CIMasterStateString || repeat <= 0 {
 		R.vipAdvRep.arm(inst, nil)
 		return
 	}

--- a/pkg/loxinet/vipadv.go
+++ b/pkg/loxinet/vipadv.go
@@ -17,9 +17,12 @@
 package loxinet
 
 import (
+	"context"
 	"net"
 	"sync"
+	"time"
 
+	cmn "github.com/loxilb-io/loxilb/common"
 	opts "github.com/loxilb-io/loxilb/options"
 	"github.com/loxilb-io/loxilb/pkg/utils"
 	tk "github.com/loxilb-io/loxilib"
@@ -276,4 +279,145 @@ func (R *RuleH) vipAdvConfIf() string {
 	}
 
 	return dev
+}
+
+// vipAdvBurst - one running advertisement burst
+type vipAdvBurst struct {
+	cancel context.CancelFunc
+}
+
+// vipAdvBurstSched - at most one advertisement burst per cluster instance
+//
+// A burst belongs to the transition that started it. The next transition of
+// the same instance, whichever way it goes, replaces it: a promotion starts a
+// fresh burst, a demotion just stops the old one, so a master that steps down
+// mid-burst does not keep claiming the VIPs for the peer that took them.
+type vipAdvBurstSched struct {
+	mx     sync.Mutex
+	active map[string]*vipAdvBurst
+}
+
+// arm - drop the burst running for inst, if any, and start run in its place
+//
+// run may be nil, which only does the drop. run gets a context that is
+// cancelled when it is replaced, and is expected to return promptly on it.
+func (s *vipAdvBurstSched) arm(inst string, run func(ctx context.Context)) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	if s.active == nil {
+		s.active = make(map[string]*vipAdvBurst)
+	}
+	if b := s.active[inst]; b != nil {
+		b.cancel()
+		delete(s.active, inst)
+	}
+	if run == nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b := &vipAdvBurst{cancel: cancel}
+	s.active[inst] = b
+
+	go func() {
+		defer func() {
+			cancel()
+			s.mx.Lock()
+			if s.active[inst] == b {
+				delete(s.active, inst)
+			}
+			s.mx.Unlock()
+		}()
+		run(ctx)
+	}()
+}
+
+// vipAdvTarget - a VIP and the interface it is advertised on
+type vipAdvTarget struct {
+	ip    net.IP
+	iface string
+}
+
+// vipAdvBurstOnState - repeat the advertisement after a MASTER transition
+//
+// The transition sends one gratuitous ARP or NA per VIP, and the next one is
+// the sweep's, up to VIPSweepDuration later. One frame is easy to lose - the
+// link may still be coming up, the switch may still be learning - and until
+// the sweep every neighbour keeps its stale entry and forwards to the old
+// master. So send a few more, VIPAdvRepeatInterval apart, the way keepalived
+// does with garp_master_repeat. Rule adds while already master are not
+// repeated: there is no stale entry to overwrite, the first ARP request
+// resolves the VIP on its own.
+//
+// Whatever the new state, a burst still running for the instance is dropped
+// first. The repeats are advertisements only: the bind, cloud hook and
+// neighbour cleanup happened on the transition and are not redone.
+func (R *RuleH) vipAdvBurstOnState(inst, ciStateStr string) {
+	repeat := opts.Opts.VIPAdvRepeat
+	if ciStateStr != cmn.CIMasterStateString || repeat <= 0 {
+		R.vipAdvRep.arm(inst, nil)
+		return
+	}
+
+	tk.LogIt(tk.LogInfo, "lb-rule vip adv - %s master, repeating %d times\n", inst, repeat)
+
+	R.vipAdvRep.arm(inst, func(ctx context.Context) {
+		for i := 0; i < repeat; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(VIPAdvRepeatInterval * time.Second):
+			}
+
+			targets := R.vipAdvBurstTargets(inst)
+			if len(targets) == 0 {
+				return
+			}
+			for _, t := range targets {
+				if ctx.Err() != nil {
+					return
+				}
+				tk.LogIt(tk.LogDebug, "lb-rule vip %s - repeat %d/%d on %s\n", t.ip.String(), i+1, repeat, t.iface)
+				vipAdvSend(t.ip, t.iface)
+			}
+		}
+	})
+}
+
+// vipAdvBurstTargets - the VIPs of inst and where each goes, nil once inst is
+// no longer master
+//
+// Resolved fresh under the lock, like the sweep does, so a routing change
+// between repeats is followed rather than remembered. The frames themselves
+// go out after the lock is dropped.
+func (R *RuleH) vipAdvBurstTargets(inst string) []vipAdvTarget {
+	mh.mtx.Lock()
+	defer mh.mtx.Unlock()
+
+	if ciState, _ := mh.has.CIStateGetInst(inst); ciState != cmn.CIMasterStateString {
+		return nil
+	}
+
+	advCtx := new(vipAdvCtx)
+	targets := make([]vipAdvTarget, 0, len(R.vipMap))
+	for vip, vipElem := range R.vipMap {
+		if vipElem.inst != inst {
+			continue
+		}
+		ip := vipElem.pVIP
+		if ip == nil {
+			ip = net.ParseIP(vip)
+		}
+		if ip == nil || ip.IsUnspecified() {
+			continue
+		}
+		iface := R.VipAdvIf(ip, advCtx)
+		if iface == "" {
+			continue
+		}
+		targets = append(targets, vipAdvTarget{ip: ip, iface: iface})
+	}
+
+	return targets
 }

--- a/pkg/loxinet/vipadv_test.go
+++ b/pkg/loxinet/vipadv_test.go
@@ -17,8 +17,10 @@
 package loxinet
 
 import (
+	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/loxilb-io/loxilb/pkg/utils"
 )
@@ -151,4 +153,98 @@ func TestLogVipAdvIfTransitions(t *testing.T) {
 	// A VIP that is not in the map must not be tracked or panic.
 	R.logVipAdvIf(ip, net.ParseIP("20.20.20.2"), "eth0")
 	R.logVipAdvIf(ip, nil, "eth0")
+}
+
+// burstProbe - a run function that reports when it starts and when its
+// context is cancelled
+type burstProbe struct {
+	started   chan struct{}
+	cancelled chan struct{}
+}
+
+func newBurstProbe() *burstProbe {
+	return &burstProbe{started: make(chan struct{}), cancelled: make(chan struct{})}
+}
+
+func (p *burstProbe) run(ctx context.Context) {
+	close(p.started)
+	<-ctx.Done()
+	close(p.cancelled)
+}
+
+func waitClosed(t *testing.T, ch chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s did not happen", what)
+	}
+}
+
+func assertOpen(t *testing.T, ch chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatalf("%s happened, should not have", what)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestVipAdvBurstSchedReplaces(t *testing.T) {
+	var s vipAdvBurstSched
+
+	first := newBurstProbe()
+	s.arm("inst0", first.run)
+	waitClosed(t, first.started, "first burst start")
+	assertOpen(t, first.cancelled, "first burst cancel")
+
+	// A second promotion of the same instance replaces the burst.
+	second := newBurstProbe()
+	s.arm("inst0", second.run)
+	waitClosed(t, first.cancelled, "first burst cancel on replace")
+	waitClosed(t, second.started, "second burst start")
+	assertOpen(t, second.cancelled, "second burst cancel")
+
+	// Another instance runs alongside, untouched.
+	other := newBurstProbe()
+	s.arm("inst1", other.run)
+	waitClosed(t, other.started, "other instance burst start")
+	assertOpen(t, second.cancelled, "second burst cancel by other instance")
+
+	// A demotion (nil run) only stops what is running.
+	s.arm("inst0", nil)
+	waitClosed(t, second.cancelled, "second burst cancel on demotion")
+	assertOpen(t, other.cancelled, "other instance burst cancel by inst0 demotion")
+
+	s.arm("inst1", nil)
+	waitClosed(t, other.cancelled, "other instance burst cancel")
+}
+
+func TestVipAdvBurstSchedForgetsFinished(t *testing.T) {
+	var s vipAdvBurstSched
+
+	done := make(chan struct{})
+	s.arm("inst0", func(ctx context.Context) { close(done) })
+	waitClosed(t, done, "burst run")
+
+	// A finished burst leaves nothing behind, so a later replacement does
+	// not cancel a stranger's context.
+	deadline := time.After(2 * time.Second)
+	for {
+		s.mx.Lock()
+		n := len(s.active)
+		s.mx.Unlock()
+		if n == 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("finished burst still registered")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Demoting an instance with no burst is a no-op.
+	s.arm("inst0", nil)
+	s.arm("never", nil)
 }


### PR DESCRIPTION
## What

After a cluster instance becomes MASTER, repeat each VIP's gratuitous ARP / NA `--vip-adv-repeat` times (default 3), one a second, the way keepalived does with `garp_master_repeat`. The periodic 30s sweep is unchanged.

## Why

A promotion sends one advertisement per VIP, and the next one is the sweep's, up to 30 seconds later. One frame is easy to lose (link still coming up, switch still learning, the peer's own advertisement crossing it) and until the sweep every neighbour keeps forwarding to the old master. sctpmh-seagull cases 2/3 showed the shape of it: two loxilbs restarted together, each briefly master, and the two gateway VIPs landed on different nodes for the next 25 seconds. #1127 fixed the harness; this is the defence for the same thing in the field.

## How

- `vipAdvBurstSched`: one burst per instance. The next transition of the instance replaces it whichever way it goes, so a master that steps down mid-burst stops claiming the VIPs. Each round also checks the instance is still MASTER before sending.
- Repeats are advertisements only. Bind, cloud hook and neighbour cleanup happened on the transition and are not redone. The interface is resolved fresh each round under the lock, like the sweep; frames go out after the lock is dropped.
- Rule adds while already master are not repeated: no stale entry to overwrite.
- The single advertisement moves into `vipAdvSend`, and its reply channel becomes buffered: a sender finishing after the 300ms deadline used to block forever.
- Builds on #1126 (`VipAdvIf`).

## Verification

- Unit tests for the scheduler's replace / demote / cleanup behaviour (`-race` clean).
- `cicd/ha1-vipadv` gains a burst assertion: capture the 8 seconds around the flip and want at least 3 gratuitous ARPs for the IPv4 VIP (the sweep can add one, so 2 proves nothing). Run locally with the patched binary: all checks OK, 4 GARPs in the window, both VIPs logged `repeat 1/3 .. 3/3` a second apart, demoted node released both VIPs.


### sctpmh-seagull, concurrent restart (the pre-#1127 harness)

Both loxilbs killed and cold-started within 0.5s, then the two gateway VIP ARPs on r1 (11.11.11.11) and r3 (10.10.10.10) sampled every 2s against the elected master. Stock image binary vs this branch, same procedure, inside the sctpmh-seagull VM.

| arm | cycles | elected at | ARPs land on the master at | outcome |
|---|---|---|---|---|
| stock, pass 1 | 3/3 | 14-16s | 40s (the sweep) | ~25s after election with the ARPs split or both on the backup |
| patched, pass 1 | 5/5 | 15-16s | 16-20s | within 0-4s of election |
| stock, pass 2 (seagull started 3s after election) | 2/3 | 16-18s | 31-33s | association came up single path: 2 CT rows, no multipath. 1/3 happened to converge at once |
| patched, pass 2 | 3/3 | 13-18s | 18-20s | 6 CT rows (3 paths x 2 directions), 81k-120k calls, 0 failed |

The usual stock failure: both nodes are briefly MASTER, the loser's gratuitous ARP lands last, and the final master has no further transition so nothing re-advertises until the sweep. The burst runs from the final master's transition for the next three seconds, so it overwrites the loser's late claim; it did in every cycle.

### Follow-up: decide on the live state

`RulesSyncToClusterState` is one goroutine per transition with no ordering between them, so a BACKUP sync arriving late could cancel the burst a newer MASTER sync had started (fewer advertisements, never more: the per-round state check already covers the other direction). `vipAdvBurstOnState` now reads the live state under `mh.mtx` and arms in the same critical section, so whichever sync runs last acts on the true state. ha1-vipadv re-run with this: all OK, 4 GARPs in the window.
