### PR TITLE
loxinet: source-NAT each secondary VIP's traffic from that VIP

### DIFF
--- a/cicd/sctpmh-seagull/check_ha.sh
+++ b/cicd/sctpmh-seagull/check_ha.sh
@@ -186,3 +186,40 @@ function restart_loxilbs() {
     # Confirm the routers actually point both gateway VIPs at the current master.
     wait_gw_arp
 }
+
+# Restart both loxilbs at once, so that whichever instance is elected MASTER
+# takes over WITHOUT any conntrack state: neither node has seen the INIT of an
+# association that outlives the restart, and neither has a peer to pull
+# conntrack from at start-up. This is the one thing restart_loxilbs is built
+# to avoid, and it is what the CT-less takeover case (validation7) needs.
+#
+# The simultaneous cold start also lets both instances claim the gateway VIPs
+# for a moment, so the routers may latch onto the loser; wait_gw_arp puts them
+# right before the caller looks at traffic.
+function restart_loxilbs_together() {
+    local n pid
+    for n in llb1 llb2; do
+        _node_opts "$n"
+        pid=$(ps -aef | grep "$_pat" | xargs | cut -d ' ' -f 2)
+        echo "Killing $n ($pid)" >&2
+        sudo kill -9 $pid
+    done
+    for n in llb1 llb2; do
+        _node_opts "$n"
+        docker exec -dt "$n" ip link del llb0
+        docker exec -dt "$n" /root/loxilb-io/loxilb/loxilb $_copts $_self $_ka
+    done
+    sleep 3
+    # Two instances electing at the same instant occasionally both settle on
+    # MASTER (BFD comes up on both within the same second and the two state
+    # notifications race). Restarting one of them alone re-runs the election
+    # against a stable peer. The CT-less takeover this helper exists for has
+    # already happened by then.
+    if ! check_ha; then
+        echo "cluster did not settle after the joint restart - restarting llb2 alone" >&2
+        restart_one llb2
+        sleep 3
+        check_ha || return 1
+    fi
+    wait_gw_arp
+}

--- a/cicd/sctpmh-seagull/validation.sh
+++ b/cicd/sctpmh-seagull/validation.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 code=0
-tc=( "Basic Test - Client & EP Uni-homed and LB is Multi-homed" "Multipath Test, Client and LB Multihomed, EP is uni-homed" "C2LB Multipath Failover Test - Client and LB Multihomed, EP is uni-homed" "E2E Multipath Failover Test - Client, LB and EP all Multihomed" "C2LB HA Failover Test - Client and LB Multihomed, EP is uni-homed" "E2E HA Failover Test. Client, LB and EP all Multihomed" )
+tc=( "Basic Test - Client & EP Uni-homed and LB is Multi-homed" "Multipath Test, Client and LB Multihomed, EP is uni-homed" "C2LB Multipath Failover Test - Client and LB Multihomed, EP is uni-homed" "E2E Multipath Failover Test - Client, LB and EP all Multihomed" "C2LB HA Failover Test - Client and LB Multihomed, EP is uni-homed" "E2E HA Failover Test. Client, LB and EP all Multihomed" "CT-less Takeover Test - both LBs cold-restarted under a live multipath association" )
 padding="............................................................................................................."
 border="**************************************************************************************************************************************************"
 
-for((j=0,i=1; i<=6; i++, j++)); do
+for((j=0,i=1; i<=7; i++, j++)); do
     echo "SCTP Multihoming - Test case #$i"
     echo -e "\n\n\n$border\n"
     # The VM writes status$i.txt into /vagrant. Start from a clean slate so a
@@ -33,7 +33,7 @@ done
 
 echo -e "\n\n\n$border\n"
 printf "================================================== SCTP MULTIHOMING CONSOLIDATED RESULT ==========================================================\n"
-for((j=0,i=1; i<=6; i++, j++)); do
+for((j=0,i=1; i<=7; i++, j++)); do
     file=status$i.txt
     status=$(cat $file 2>/dev/null)
     title=${tc[j]}

--- a/cicd/sctpmh-seagull/validation7.sh
+++ b/cicd/sctpmh-seagull/validation7.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+source /home/vagrant/common.sh
+source /vagrant/check_ha.sh
+
+echo -e "sctpmh: SCTP Multihoming - CT-less Takeover Test. Both LBs cold-restarted under a live multipath association\n"
+extIP="20.20.20.1"
+port=2020
+
+# What this checks: a loxilb that takes over an SCTP association it never saw
+# the INIT of (mhon=0, closed->EST recovery) keeps ALL of the association's
+# paths, not just the first one to send a packet.
+#
+# Each secondary VIP's NAT entry used to share the primary VIP's action block,
+# so on such a node every path source-NATed from the primary VIP and the
+# kernel derived the same reverse conntrack key (EP -> primary VIP) for all
+# three. The first path to arrive got its conntrack entry; the other two were
+# dropped at conntrack creation for as long as the association lived. Seen as
+# two conntrack rows instead of six, a reverse row whose SNAT source is a
+# different VIP than its key, two path counters that never move, and every
+# call timing out once the client's primary path is one of the dead ones.
+#
+# Both loxilbs are restarted together on purpose: restarted one at a time, the
+# survivor hands its conntrack to the other at start-up and no CT-less takeover
+# ever happens - which is also why cases 5 and 6 do not catch this.
+
+check_ha || { echo "NOK" > /vagrant/status7.txt; exit 1; }
+
+echo "SCTP Multihoming service sctp-lb(Multipath traffic) -> $extIP:$port"
+echo -e "------------------------------------------------------------------------------------\n"
+echo -e "\nHA state Master:$master BACKUP-$backup\n"
+echo -e "\nTraffic Flow: User -> LB -> EP "
+
+# A long-lived association at a modest call rate, so it outlives the restart.
+sudo docker exec -dt user ksh -c "sed -i 's/\"call-rate\" value=\"5000\"/\"call-rate\" value=\"100\"/g' /opt/seagull/diameter-env/config/conf.client.xml"
+
+sudo docker exec -dt ep1 ksh -c 'export LD_PRELOAD=/usr/local/bin/libsctplib.so.1.0.8; export LD_LIBRARY_PATH=/usr/local/bin; cd /opt/seagull/diameter-env/run/; timeout 200 stdbuf -oL seagull -conf ../config/conf.server.xml -dico ../config/base_s6a.xml -scen ../scenario/ulr-ula.server.xml > ep1.out' 2>&1 > /dev/null &
+sleep 2
+sudo docker exec -dt user ksh -c 'export LD_PRELOAD=/usr/local/bin/libsctplib.so.1.0.8; export LD_LIBRARY_PATH=/usr/local/bin; cd /opt/seagull/diameter-env/run/; timeout 190 stdbuf -oL seagull -conf ../config/conf.client.xml -dico ../config/base_s6a.xml -scen ../scenario/ulr-ula.client.xml > user.out' 2>&1 > /dev/null &
+
+# Let the association settle and the multipath entries take shape.
+sleep 25
+
+# Forward conntrack rows of the three paths, and their packet counters.
+# Row layout: | service | dip | sip | dport | sport | proto | ... | state | act | packets | bytes |
+ct_rows() { sudo docker exec -i $master loxicmd get ct --servName=sctpmh1 2>/dev/null | grep -w est; }
+fwd_row() { ct_rows | grep "$1" | grep fdnat | head -1; }
+row_pkts() { echo "$1" | xargs | cut -d '|' -f 11 | tr -d ' '; }
+row_snat() { echo "$1" | grep -o 'fdnat-[0-9.]*' | cut -d '-' -f 2; }
+calls() { sudo docker exec -t user bash -c "tail -n 10 /opt/seagull/diameter-env/run/user.out | grep '$1 calls'" | xargs | cut -d '|' -f 4 | tr -d ' '; }
+
+paths=( "20.20.20.1 | 1.1.1.1" "21.21.21.1 | 2.2.2.1" "22.22.22.1 | 1.1.1.1" )
+vips=( "20.20.20.1" "21.21.21.1" "22.22.22.1" )
+
+code=0
+echo -e "\nBefore restart: conntrack on MASTER $master\n"
+ct_rows
+for k in 0 1 2; do
+    r=$(fwd_row "${paths[$k]}")
+    if [[ -z "$r" ]]; then echo "Path $((k+1)) ${paths[$k]} has no conntrack before the restart [NOK]"; code=1; fi
+done
+if [[ $code != 0 ]]; then
+    echo "NOK" > /vagrant/status7.txt
+    echo "sctpmh SCTP Multihoming CT-less Takeover [NOK] - association did not form"
+    exit 1
+fi
+calls_before=$(calls Successful)
+echo "Successful calls before restart: $calls_before"
+
+echo -e "\nCold-restarting both loxilbs under the live association\n"
+restart_loxilbs_together || { echo "NOK" > /vagrant/status7.txt; exit 1; }
+echo -e "\nHA state after restart Master:$master BACKUP-$backup\n"
+
+# The taking-over node builds conntrack from the packets it sees. Give it a
+# moment, then sample twice so the counters can show movement. The client
+# sends its calls down one path and only heartbeats down the other two, so
+# the window has to be long enough for a heartbeat on each.
+sleep 10
+declare -a p_old p_new
+for k in 0 1 2; do p_old[$k]=$(row_pkts "$(fwd_row "${paths[$k]}")"); done
+fail_old=$(calls Failed)
+sleep 30
+for k in 0 1 2; do p_new[$k]=$(row_pkts "$(fwd_row "${paths[$k]}")"); done
+fail_new=$(calls Failed)
+calls_after=$(calls Successful)
+
+echo -e "\nAfter takeover: conntrack on MASTER $master\n"
+ct_rows
+echo
+
+for k in 0 1 2; do
+    r=$(fwd_row "${paths[$k]}")
+    if [[ -z "$r" ]]; then
+        echo "Path $((k+1)) ${paths[$k]}: no conntrack after takeover [NOK]"
+        code=1
+        continue
+    fi
+    snat=$(row_snat "$r")
+    if [[ "$snat" != "${vips[$k]}" ]]; then
+        echo "Path $((k+1)) ${paths[$k]}: SNAT source $snat, want ${vips[$k]} [NOK]"
+        code=1
+    else
+        echo "Path $((k+1)) ${paths[$k]}: SNAT source $snat [OK]"
+    fi
+    if [[ "${p_new[$k]:-0}" -gt "${p_old[$k]:-0}" ]]; then
+        echo "Path $((k+1)) ${paths[$k]}: packets ${p_old[$k]} -> ${p_new[$k]} [ACTIVE]"
+    else
+        echo "Path $((k+1)) ${paths[$k]}: packets ${p_old[$k]:-0} -> ${p_new[$k]:-0} [NOT ACTIVE] [NOK]"
+        code=1
+    fi
+done
+
+if [[ "${fail_new:-0}" -gt "${fail_old:-0}" ]]; then
+    printf "Failed Calls:   \t%10s -> %10s \t[INCREASING] [NOK]\n" "$fail_old" "$fail_new"
+    code=1
+else
+    printf "Failed Calls:   \t%10s -> %10s \t[STABLE]\n" "${fail_old:-0}" "${fail_new:-0}"
+fi
+if [[ "${calls_after:-0}" -gt "${calls_before:-0}" ]]; then
+    printf "Successful Calls: \t%10s -> %10s \t[ACTIVE]\n" "$calls_before" "$calls_after"
+else
+    printf "Successful Calls: \t%10s -> %10s \t[NOT ACTIVE] [NOK]\n" "${calls_before:-0}" "${calls_after:-0}"
+    code=1
+fi
+
+#Restore
+sudo docker exec -dt user ksh -c "sed -i 's/\"call-rate\" value=\"100\"/\"call-rate\" value=\"5000\"/g' /opt/seagull/diameter-env/config/conf.client.xml"
+sudo docker exec -i user pkill -f seagull >/dev/null 2>&1
+sudo docker exec -i ep1 pkill -f seagull >/dev/null 2>&1
+
+if [[ $code == 0 ]]; then
+    echo "sctpmh SCTP Multihoming CT-less Takeover [OK]"
+    echo "OK" > /vagrant/status7.txt
+else
+    echo "NOK" > /vagrant/status7.txt
+    echo "sctpmh SCTP Multihoming CT-less Takeover [NOK]"
+    echo -e "\nllb1 lb-info"
+    $dexec llb1 loxicmd get lb
+    echo -e "\nllb2 lb-info"
+    $dexec llb2 loxicmd get lb
+    echo "-----------------------------"
+    exit 1
+fi
+echo -e "------------------------------------------------------------------------------------\n\n\n"

--- a/pkg/loxinet/dpebpf_linux.go
+++ b/pkg/loxinet/dpebpf_linux.go
@@ -966,6 +966,52 @@ func setNatKeyDaddr(key *natKey, ip net.IP) {
 	}
 }
 
+// secIPNatActs - the NAT action block to install under a secondary VIP
+//
+// A secondary VIP gets its own copy of the primary's block, and in that copy
+// every endpoint that source-NATs does so from the secondary VIP instead of
+// the primary. The kernel builds the reverse conntrack key from nat_rip
+// (EP -> nat_rip), so with one block shared by all the VIPs every path of an
+// SCTP association had the same reverse key on a node that had not seen the
+// INIT: the first path to arrive got a conntrack entry and every other path
+// was dropped at conntrack creation, for the life of the association. The
+// multipath pre-creation path in the kernel already keys each path on its own
+// VIP; this makes the map install agree with it.
+//
+// Only DNAT-type blocks are touched. An endpoint whose nat_rip is zero (a
+// plain DNAT rule, or an endpoint that is the VIP itself or a local address)
+// is left alone: the kernel then keys the reverse entry on the original
+// daddr, which already is the secondary VIP, and adding a source NAT there
+// would change behaviour. A full-proxy block is returned as is - its
+// endpoints are proxy arguments, not a NAT transform.
+func secIPNatActs(dat *proxyActs, sip net.IP) *proxyActs {
+	if dat.ca.act_type != C.DP_SET_DNAT {
+		return dat
+	}
+
+	sDat := new(proxyActs)
+	*sDat = *dat
+
+	v6 := tk.IsNetIPv6(sip.String())
+	for i := 0; i < int(sDat.nxfrm) && i < len(sDat.nxfrms); i++ {
+		nxfa := (*nxfrmAct)(unsafe.Pointer(&sDat.nxfrms[i]))
+		if nxfa.nat_rip[0] == 0 && nxfa.nat_rip[1] == 0 &&
+			nxfa.nat_rip[2] == 0 && nxfa.nat_rip[3] == 0 {
+			continue
+		}
+		if (nxfa.nv6 == 1) != v6 {
+			continue
+		}
+		if v6 {
+			convNetIP2DPv6Addr(unsafe.Pointer(&nxfa.nat_rip[0]), sip)
+		} else {
+			nxfa.nat_rip = [4]C.uint{C.uint(tk.IPtonl(sip)), 0, 0, 0}
+		}
+	}
+
+	return sDat
+}
+
 // DpLBRuleMod - routine to work on a ebpf lb change request
 func DpLBRuleMod(w *LBDpWorkQ) int {
 
@@ -1109,6 +1155,8 @@ func DpLBRuleMod(w *LBDpWorkQ) int {
 		// Add a dataplane NAT entry for each secondary VIP so SCTP packets
 		// addressed to a secondary VIP follow the same action as the primary VIP.
 		// Skip SNAT and fwmark-based NAT entries because they are not keyed on daddr.
+		// The action block is the primary's, except that the secondary VIP
+		// source-NATs from itself: see secIPNatActs.
 		if w.NatType != DpSnat && w.NatType != DpNat {
 			for _, sip := range w.secIP {
 				sKey := new(natKey)
@@ -1116,7 +1164,7 @@ func DpLBRuleMod(w *LBDpWorkQ) int {
 				setNatKeyDaddr(sKey, sip)
 				sret := C.llb_add_map_elem(C.LL_DP_NAT_MAP,
 					unsafe.Pointer(sKey),
-					unsafe.Pointer(dat))
+					unsafe.Pointer(secIPNatActs(dat, sip)))
 				if sret != 0 {
 					// Log the failure and continue after installing the primary entry.
 					tk.LogIt(tk.LogError, "[DP] LB rule secIP %s:%v add[NOK]\n", sip.String(), sKey.mark)


### PR DESCRIPTION
## What

Each secondary VIP of an SCTP rule gets its own NAT action block in which every source-NATing endpoint uses the secondary VIP as `nat_rip`, instead of sharing the primary VIP's block. Plus a sctpmh-seagull case that exercises the failure.

## Why

`nat_rip` is the fullnat SNAT source, and the kernel derives the reverse conntrack key from it (`EP -> nat_rip`, `llb_kern_ct.c` LLB_NAT_DST branch). With one block shared by all VIPs, on a node that has not seen the association's INIT (mhon=0, the closed->EST recovery restored by #1101) all three paths of a multihomed association map to the same reverse key. The first path to send a packet gets its conntrack pair; the other two find the reverse key taken and are dropped at conntrack creation (`LLB_PIPE_CT_ERR`), for the life of the association. There is no self-healing.

A node that saw the INIT is fine: the kernel's multipath pre-creation keys each path on its own VIP. This makes the map install (added by #1090 for #1078) agree with it.

## Reproduction (stock `ghcr.io/loxilb-io/loxilb:latest`, sctpmh-seagull VM)

Long-lived multipath association through the master, then both loxilbs cold-restarted together so the elected node takes over with no conntrack:

| run | conntrack on the taking-over node | surviving path | calls after takeover |
|---|---|---|---|
| 1 | 6 rows -> **2 rows** | path 2 (2.2.2.1->21.21.21.1) | 0 successful, 5,704 timeouts |
| 2 | 2 rows | path 3 (1.1.1.1->22.22.22.1) | 0 successful, 8,477 timeouts |

The two rows show the mechanism directly: the forward row SNATs from the primary VIP (`fdnat-20.20.20.1,31.31.31.1`) and the reverse row is `20.20.20.1|31.31.31.1 fsnat-<the surviving secondary VIP>`. The other two paths have no rows at all, and the EP sees a single source address. Which path survives is whichever packet arrives first. When the client's primary path is one of the dead ones, every call times out.

A sequential restart does **not** reproduce it: the restarted node pulls conntrack from the surviving peer at start-up, so cases 5 and 6 never see a CT-less takeover. The real triggers are both nodes cold-restarting, a failover inside the ~10s xsync delay after establishment, or a lost map-trace event.

## The fix, and its edges

- Only DNAT-type blocks are copied. Endpoints with `nat_rip` zero (plain DNAT, or an endpoint that is the VIP itself or a local address) are left alone: the kernel keys their reverse entry on the original daddr, which already is the secondary VIP. Full-proxy blocks are returned unchanged.
- IPv6 secondary VIPs take the v6 conversion; a family mismatch between VIP and endpoint is skipped.
- Visible change: an INIT sent directly to a secondary VIP is now source-NATed from that VIP rather than the primary. The endpoint already knows that address from the INIT-ACK.

## Verification (fix binary built in an ubuntu:22.04 container)

- New sctpmh-seagull case 7: **NOK on the stock binary** (no rows for any path after takeover, calls stalled), **OK with the fix**: six rows, each path's SNAT source is its own VIP, all three paths moving, failed calls stable, successful calls 2,398 -> 6,681.
- sctpmh-seagull cases 2 and 5 with the fix: OK.
- `cicd/sctpmh-secip-direct` validation and validation2 with the fix: OK (the direct-to-secondary-VIP path whose SNAT source changes).

`restart_loxilbs_together` in check_ha.sh is the deliberate opposite of `restart_loxilbs`. Two instances electing at the same instant occasionally both settle on MASTER (seen once in about fifteen joint restarts, BFD up on both, the two state notifications racing); the helper then restarts llb2 alone. That election race is pre-existing and separate from this change.

Refs #1078, #1090, #1101.
