### PR TITLE
fix: prevent XSync RPC deadlocks and preserve CT retries

### DIFF
--- a/pkg/loxinet/dpbroker.go
+++ b/pkg/loxinet/dpbroker.go
@@ -367,6 +367,9 @@ type DpCtInfo struct {
 	LTs     time.Time `json:"lts"`
 	NTs     time.Time `json:"nts"`
 	XSync   bool      `json:"xsync"`
+	// SyncRetries is local bookkeeping for bounded CT-add synchronization.
+	// It is intentionally omitted from JSON and the gRPC conversion.
+	SyncRetries int `json:"-"`
 
 	// LB Association Data
 	ServiceIP     net.IP `json:"serviceip"`
@@ -513,17 +516,6 @@ type DpH struct {
 	Peers     []DpPeer
 	RPC       *XSync
 	Remotes   []XSync
-}
-
-// DpXsyncRPCReset - Routine to reset Sunc RPC Client connections
-func (dp *DpH) DpXsyncRPCReset() int {
-	dp.SyncMtx.Lock()
-	defer dp.SyncMtx.Unlock()
-	for idx := range mh.dp.Peers {
-		pe := &mh.dp.Peers[idx]
-		dp.RPC.RPCHooks.RPCReset(pe)
-	}
-	return 0
 }
 
 // DpXsyncInSync - Routine to check if remote peer is in sync

--- a/pkg/loxinet/dpbroker.go
+++ b/pkg/loxinet/dpbroker.go
@@ -504,14 +504,15 @@ type DpPeer struct {
 
 // DpH - datapath context container
 type DpH struct {
-	ToDpCh   chan interface{}
-	FromDpCh chan interface{}
-	ToFinCh  chan int
-	DpHooks  DpHookInterface
-	SyncMtx  sync.RWMutex
-	Peers    []DpPeer
-	RPC      *XSync
-	Remotes  []XSync
+	ToDpCh    chan interface{}
+	FromDpCh  chan interface{}
+	ToFinCh   chan int
+	DpHooks   DpHookInterface
+	SyncMtx   sync.RWMutex
+	RemoteMtx sync.RWMutex
+	Peers     []DpPeer
+	RPC       *XSync
+	Remotes   []XSync
 }
 
 // DpXsyncRPCReset - Routine to reset Sunc RPC Client connections
@@ -527,8 +528,8 @@ func (dp *DpH) DpXsyncRPCReset() int {
 
 // DpXsyncInSync - Routine to check if remote peer is in sync
 func (dp *DpH) DpXsyncInSync() bool {
-	dp.SyncMtx.Lock()
-	defer dp.SyncMtx.Unlock()
+	dp.RemoteMtx.RLock()
+	defer dp.RemoteMtx.RUnlock()
 
 	return len(dp.Remotes) >= len(mh.has.NodeMap)
 }

--- a/pkg/loxinet/dpebpf_linux.go
+++ b/pkg/loxinet/dpebpf_linux.go
@@ -341,7 +341,9 @@ func DpEbpfInit(clusterEn, rssEn, egrHooks, localSockPolicy, sockMapEn bool, nod
 	for i := 0; i < mapNotifierWorkers; i++ {
 		ne.ToFinCh[i] = make(chan int)
 	}
-	ne.ctBcast = make(chan bool)
+	// Coalesce concurrent full-sync requests and, importantly, never block an
+	// inbound RPC handler waiting for the datapath ticker to receive the event.
+	ne.ctBcast = make(chan bool, 1)
 	ne.ticker = time.NewTicker(dpEbpfLinuxTiVal * time.Second)
 	ne.ctMap = make(map[string]*DpCtInfo)
 	ne.RssEn = rssEn
@@ -2375,9 +2377,69 @@ func dpCTMapBcast() {
 	tk.LogIt(tk.LogInfo, "[CT]  CTBcast Complete \n")
 }
 
-func dpCTMapChkUpdates() {
+func cloneDpCtInfo(cti *DpCtInfo) DpCtInfo {
+	clone := *cti
+	clone.DIP = append(net.IP(nil), cti.DIP...)
+	clone.SIP = append(net.IP(nil), cti.SIP...)
+	clone.ServiceIP = append(net.IP(nil), cti.ServiceIP...)
+	clone.PKey = append([]byte(nil), cti.PKey...)
+	clone.PVal = append([]byte(nil), cti.PVal...)
+	return clone
+}
+
+func dpCTMapFinishSync(block []DpCtInfo, deleteOp, succeeded bool) {
 	mh.dpEbpf.mtx.Lock()
 	defer mh.dpEbpf.mtx.Unlock()
+
+	for idx := range block {
+		synced := &block[idx]
+		key := synced.Key()
+		current := mh.dpEbpf.ctMap[key]
+		if current == nil || !current.NTs.Equal(synced.NTs) || current.Deleted != synced.Deleted {
+			continue
+		}
+
+		if succeeded {
+			if deleteOp {
+				delete(mh.dpEbpf.ctMap, key)
+			} else {
+				current.XSync = false
+			}
+			continue
+		}
+
+		// Keep failed additions pending for the next datapath tick. Deletes are
+		// retried a bounded number of times so an unavailable peer cannot retain
+		// stale shadow state forever.
+		if deleteOp && current.Deleted > ctiDeleteSyncRetries {
+			delete(mh.dpEbpf.ctMap, key)
+		}
+	}
+}
+
+func dpCTMapSyncBlocks(op DpSyncOpT, entries []DpCtInfo) {
+	deleteOp := op == DpSyncDelete
+	operation := "Add"
+	if deleteOp {
+		operation = "Del"
+	}
+
+	for start := 0; start < len(entries); start += blkCtiMaxLen {
+		end := start + blkCtiMaxLen
+		if end > len(entries) {
+			end = len(entries)
+		}
+		block := entries[start:end]
+		tk.LogIt(tk.LogTrace, "[CT] Block %s Sync - \n", operation)
+		started := time.Now()
+		ret := mh.dp.DpXsyncRPC(op, block)
+		tk.LogIt(tk.LogTrace, "[CT] Block %s Sync %d took %v- \n", operation, len(block), time.Since(started))
+		dpCTMapFinishSync(block, deleteOp, ret == 0)
+	}
+}
+
+func dpCTMapChkUpdates() {
+	mh.dpEbpf.mtx.Lock()
 	var tact C.struct_dp_ct_tact
 	var act *C.struct_dp_ct_dat
 	var blkCti []DpCtInfo
@@ -2470,55 +2532,22 @@ func dpCTMapChkUpdates() {
 		if cti.XSync == true &&
 			time.Duration(tc.Sub(cti.NTs).Seconds()) >= time.Duration(10) {
 			tk.LogIt(tk.LogTrace, "[CT] Sync - %s\n", cti.String())
-
-			ret := 0
 			if cti.Deleted > 0 {
-				//ret = mh.dp.DpXsyncRPC(DpSyncDelete, cti)
-				blkDelCti = append(blkDelCti, *cti)
 				cti.Deleted++
+				blkDelCti = append(blkDelCti, cloneDpCtInfo(cti))
 			} else {
-				blkCti = append(blkCti, *cti)
-				//ret = mh.dp.DpXsyncRPC(DpSyncAdd, cti)
-			}
-			if ret == 0 || cti.Deleted > ctiDeleteSyncRetries {
-				cti.XSync = false
-
-				if cti.Deleted > 0 {
-					delete(mh.dpEbpf.ctMap, cti.Key())
-					// This is a strange fix - See comment above. Do we still need it ?
-					// C.llb_del_map_elem(C.LL_DP_CT_MAP, unsafe.Pointer(&cti.PKey[0]))
-				}
+				blkCti = append(blkCti, cloneDpCtInfo(cti))
 			}
 		}
-
-		if len(blkCti) >= blkCtiMaxLen {
-			tk.LogIt(tk.LogTrace, "[CT] Block Add Sync - \n")
-			tc1 := time.Now()
-			mh.dp.DpXsyncRPC(DpSyncAdd, blkCti)
-			tc2 := time.Now()
-			tk.LogIt(tk.LogTrace, "[CT] Block Add Sync %d took %v- \n", len(blkCti), time.Duration(tc2.Sub(tc1)))
-			blkCti = nil
-		}
-
-		if len(blkDelCti) >= blkCtiMaxLen {
-			tk.LogIt(tk.LogTrace, "[CT] Block Del Sync - \n")
-			mh.dp.DpXsyncRPC(DpSyncDelete, blkDelCti)
-			blkDelCti = nil
-		}
 	}
 
-	if len(blkCti) > 0 {
-		tc1 := time.Now()
-		tk.LogIt(tk.LogTrace, "[CT] Block Add Sync - \n")
-		mh.dp.DpXsyncRPC(DpSyncAdd, blkCti)
-		tc2 := time.Now()
-		tk.LogIt(tk.LogTrace, "[CT] Block Add Sync %d took %v- \n", len(blkCti), time.Duration(tc2.Sub(tc1)))
-	}
+	// Never hold the datapath CT mutex while waiting for a network RPC. Apart
+	// from blocking REST reads, doing so lets two peers deadlock while each
+	// inbound CT add waits for the other peer's local datapath mutex.
+	mh.dpEbpf.mtx.Unlock()
 
-	if len(blkDelCti) > 0 {
-		tk.LogIt(tk.LogTrace, "[CT] Block Del Sync - \n")
-		mh.dp.DpXsyncRPC(DpSyncDelete, blkDelCti)
-	}
+	dpCTMapSyncBlocks(DpSyncAdd, blkCti)
+	dpCTMapSyncBlocks(DpSyncDelete, blkDelCti)
 }
 
 // dpMapNotifierWorker - Work on any map notifications
@@ -2632,7 +2661,10 @@ func (e *DpEbpfH) DpCtDel(w *DpCtInfo) int {
 
 // DpCtGetAsync - routine to work on a ebpf ct get async request
 func (e *DpEbpfH) DpCtGetAsync() {
-	e.ctBcast <- true
+	select {
+	case e.ctBcast <- true:
+	default:
+	}
 }
 
 // DpTakeLock - routine to take underlying DP lock

--- a/pkg/loxinet/dpebpf_linux.go
+++ b/pkg/loxinet/dpebpf_linux.go
@@ -103,6 +103,7 @@ const (
 const (
 	dpEbpfLinuxTiVal     = 5
 	ctGCTiValDefault     = 15
+	ctiAddSyncRetries    = 3
 	ctiDeleteSyncRetries = 3
 	blkCtiMaxLen         = 8192
 	mapNotifierChLen     = 8096
@@ -2364,6 +2365,7 @@ func dpCTMapBcast() {
 
 	for _, cti := range mh.dpEbpf.ctMap {
 		if cti.Deleted <= 0 && cti.CState == "est" {
+			cti.SyncRetries = 0
 			cti.XSync = true
 		}
 	}
@@ -2387,37 +2389,46 @@ func cloneDpCtInfo(cti *DpCtInfo) DpCtInfo {
 	return clone
 }
 
-func dpCTMapFinishSync(block []DpCtInfo, deleteOp, succeeded bool) {
-	mh.dpEbpf.mtx.Lock()
-	defer mh.dpEbpf.mtx.Unlock()
+func dpCTMapFinishSync(dp *DpEbpfH, block []DpCtInfo, deleteOp, succeeded bool) {
+	dp.mtx.Lock()
+	defer dp.mtx.Unlock()
 
 	for idx := range block {
 		synced := &block[idx]
 		key := synced.Key()
-		current := mh.dpEbpf.ctMap[key]
+		current := dp.ctMap[key]
 		if current == nil || !current.NTs.Equal(synced.NTs) || current.Deleted != synced.Deleted {
 			continue
 		}
 
 		if succeeded {
 			if deleteOp {
-				delete(mh.dpEbpf.ctMap, key)
+				delete(dp.ctMap, key)
 			} else {
 				current.XSync = false
+				current.SyncRetries = 0
 			}
 			continue
 		}
 
-		// Keep failed additions pending for the next datapath tick. Deletes are
-		// retried a bounded number of times so an unavailable peer cannot retain
-		// stale shadow state forever.
-		if deleteOp && current.Deleted > ctiDeleteSyncRetries {
-			delete(mh.dpEbpf.ctMap, key)
+		if deleteOp {
+			// Deletes are retried a bounded number of times so an unavailable peer
+			// cannot retain stale shadow state forever.
+			if current.Deleted > ctiDeleteSyncRetries {
+				delete(dp.ctMap, key)
+			}
+		} else if current.SyncRetries > ctiAddSyncRetries {
+			// A rejected entry makes the whole block fail, so retain additions for
+			// a few ticks to cover transient rule-ordering and transport failures,
+			// but do not retry an unsendable block forever.
+			current.XSync = false
+			current.SyncRetries = 0
 		}
 	}
 }
 
-func dpCTMapSyncBlocks(op DpSyncOpT, entries []DpCtInfo) {
+func dpCTMapSyncBlocks(dp *DpEbpfH, op DpSyncOpT, entries []DpCtInfo,
+	syncRPC func(DpSyncOpT, interface{}) int) bool {
 	deleteOp := op == DpSyncDelete
 	operation := "Add"
 	if deleteOp {
@@ -2432,10 +2443,16 @@ func dpCTMapSyncBlocks(op DpSyncOpT, entries []DpCtInfo) {
 		block := entries[start:end]
 		tk.LogIt(tk.LogTrace, "[CT] Block %s Sync - \n", operation)
 		started := time.Now()
-		ret := mh.dp.DpXsyncRPC(op, block)
+		ret := syncRPC(op, block)
 		tk.LogIt(tk.LogTrace, "[CT] Block %s Sync %d took %v- \n", operation, len(block), time.Since(started))
-		dpCTMapFinishSync(block, deleteOp, ret == 0)
+		dpCTMapFinishSync(dp, block, deleteOp, ret == 0)
+		if ret != 0 {
+			// The remaining entries stay pending and will be retried on the next
+			// datapath tick. This bounds a peer outage to one failed block per tick.
+			return false
+		}
 	}
+	return true
 }
 
 func dpCTMapChkUpdates() {
@@ -2521,6 +2538,7 @@ func dpCTMapChkUpdates() {
 						if cti.Packets != p+uint64(tact.ctd.pb.packets) {
 							cti.Bytes = b + uint64(tact.ctd.pb.bytes)
 							cti.Packets = p + uint64(tact.ctd.pb.packets)
+							cti.SyncRetries = 0
 							cti.XSync = true
 							cti.NTs = tc
 							cti.LTs = tc
@@ -2536,18 +2554,21 @@ func dpCTMapChkUpdates() {
 				cti.Deleted++
 				blkDelCti = append(blkDelCti, cloneDpCtInfo(cti))
 			} else {
+				cti.SyncRetries++
 				blkCti = append(blkCti, cloneDpCtInfo(cti))
 			}
 		}
 	}
 
-	// Never hold the datapath CT mutex while waiting for a network RPC. Apart
-	// from blocking REST reads, doing so lets two peers deadlock while each
-	// inbound CT add waits for the other peer's local datapath mutex.
+	// Never hold the datapath CT mutex while waiting for a network RPC. Doing so
+	// blocks inbound CT add/delete operations and the map notifier worker, and
+	// lets two peers deadlock while each inbound add waits for the other's mutex.
 	mh.dpEbpf.mtx.Unlock()
 
-	dpCTMapSyncBlocks(DpSyncAdd, blkCti)
-	dpCTMapSyncBlocks(DpSyncDelete, blkDelCti)
+	if !dpCTMapSyncBlocks(mh.dpEbpf, DpSyncAdd, blkCti, mh.dp.DpXsyncRPC) {
+		return
+	}
+	dpCTMapSyncBlocks(mh.dpEbpf, DpSyncDelete, blkDelCti, mh.dp.DpXsyncRPC)
 }
 
 // dpMapNotifierWorker - Work on any map notifications
@@ -2622,6 +2643,7 @@ func (e *DpEbpfH) DpCtAdd(w *DpCtInfo) int {
 	}
 
 	cte.XSync = false
+	cte.SyncRetries = 0
 	cte.NTs = time.Now()
 	//cte.LTs = cti.NTs
 	cte.LTs = time.Now()

--- a/pkg/loxinet/xsync_liveness_test.go
+++ b/pkg/loxinet/xsync_liveness_test.go
@@ -43,9 +43,6 @@ func TestDpCtGetAsyncCoalescesWithoutBlocking(t *testing.T) {
 }
 
 func TestDpCTMapFinishSyncUsesRPCResult(t *testing.T) {
-	original := mh.dpEbpf
-	t.Cleanup(func() { mh.dpEbpf = original })
-
 	ct := &DpCtInfo{
 		DIP:    net.ParseIP("172.30.250.201"),
 		SIP:    net.ParseIP("192.168.64.2"),
@@ -56,24 +53,24 @@ func TestDpCTMapFinishSyncUsesRPCResult(t *testing.T) {
 		NTs:    time.Unix(1, 0),
 		XSync:  true,
 	}
-	mh.dpEbpf = &DpEbpfH{ctMap: map[string]*DpCtInfo{ct.Key(): ct}}
+	dp := &DpEbpfH{ctMap: map[string]*DpCtInfo{ct.Key(): ct}}
 	block := []DpCtInfo{cloneDpCtInfo(ct)}
 
-	dpCTMapFinishSync(block, false, false)
+	dpCTMapFinishSync(dp, block, false, false)
 	if !ct.XSync {
 		t.Fatal("failed CT add was marked synchronized")
 	}
 
-	dpCTMapFinishSync(block, false, true)
+	dpCTMapFinishSync(dp, block, false, true)
 	if ct.XSync {
 		t.Fatal("successful CT add remained pending")
+	}
+	if ct.SyncRetries != 0 {
+		t.Fatalf("successful CT add retry count = %d, want 0", ct.SyncRetries)
 	}
 }
 
 func TestDpCTMapFinishSyncDoesNotAcknowledgeNewerUpdate(t *testing.T) {
-	original := mh.dpEbpf
-	t.Cleanup(func() { mh.dpEbpf = original })
-
 	ct := &DpCtInfo{
 		DIP:    net.ParseIP("172.30.250.202"),
 		SIP:    net.ParseIP("192.168.64.2"),
@@ -84,12 +81,53 @@ func TestDpCTMapFinishSyncDoesNotAcknowledgeNewerUpdate(t *testing.T) {
 		NTs:    time.Unix(1, 0),
 		XSync:  true,
 	}
-	mh.dpEbpf = &DpEbpfH{ctMap: map[string]*DpCtInfo{ct.Key(): ct}}
+	dp := &DpEbpfH{ctMap: map[string]*DpCtInfo{ct.Key(): ct}}
 	block := []DpCtInfo{cloneDpCtInfo(ct)}
 
 	ct.NTs = time.Unix(2, 0)
-	dpCTMapFinishSync(block, false, true)
+	dpCTMapFinishSync(dp, block, false, true)
 	if !ct.XSync {
 		t.Fatal("an old RPC result acknowledged a newer CT update")
+	}
+}
+
+func TestDpCTMapFinishSyncBoundsAddRetries(t *testing.T) {
+	ct := &DpCtInfo{
+		DIP:         net.ParseIP("172.30.250.201"),
+		SIP:         net.ParseIP("192.168.64.2"),
+		Dport:       18081,
+		Sport:       50100,
+		Proto:       "tcp",
+		CState:      "est",
+		NTs:         time.Unix(1, 0),
+		XSync:       true,
+		SyncRetries: ctiAddSyncRetries + 1,
+	}
+	dp := &DpEbpfH{ctMap: map[string]*DpCtInfo{ct.Key(): ct}}
+	block := []DpCtInfo{cloneDpCtInfo(ct)}
+
+	dpCTMapFinishSync(dp, block, false, false)
+	if ct.XSync {
+		t.Fatal("CT add remained pending after exceeding its retry limit")
+	}
+	if ct.SyncRetries != 0 {
+		t.Fatalf("abandoned CT add retry count = %d, want 0", ct.SyncRetries)
+	}
+}
+
+func TestDpCTMapSyncBlocksStopsAfterFailure(t *testing.T) {
+	dp := &DpEbpfH{ctMap: make(map[string]*DpCtInfo)}
+	entries := make([]DpCtInfo, blkCtiMaxLen+1)
+	calls := 0
+	syncRPC := func(_ DpSyncOpT, _ interface{}) int {
+		calls++
+		return -1
+	}
+
+	if dpCTMapSyncBlocks(dp, DpSyncAdd, entries, syncRPC) {
+		t.Fatal("failed CT block sync reported success")
+	}
+	if calls != 1 {
+		t.Fatalf("RPC calls after first failed block = %d, want 1", calls)
 	}
 }

--- a/pkg/loxinet/xsync_liveness_test.go
+++ b/pkg/loxinet/xsync_liveness_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 LoxiLB Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package loxinet
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestDpCtGetAsyncCoalescesWithoutBlocking(t *testing.T) {
+	dp := &DpEbpfH{ctBcast: make(chan bool, 1)}
+	dp.DpCtGetAsync()
+
+	done := make(chan struct{})
+	go func() {
+		dp.DpCtGetAsync()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("a duplicate CT broadcast request blocked the RPC handler")
+	}
+
+	if got := len(dp.ctBcast); got != 1 {
+		t.Fatalf("queued CT broadcast requests = %d, want 1", got)
+	}
+}
+
+func TestDpCTMapFinishSyncUsesRPCResult(t *testing.T) {
+	original := mh.dpEbpf
+	t.Cleanup(func() { mh.dpEbpf = original })
+
+	ct := &DpCtInfo{
+		DIP:    net.ParseIP("172.30.250.201"),
+		SIP:    net.ParseIP("192.168.64.2"),
+		Dport:  18081,
+		Sport:  50100,
+		Proto:  "tcp",
+		CState: "est",
+		NTs:    time.Unix(1, 0),
+		XSync:  true,
+	}
+	mh.dpEbpf = &DpEbpfH{ctMap: map[string]*DpCtInfo{ct.Key(): ct}}
+	block := []DpCtInfo{cloneDpCtInfo(ct)}
+
+	dpCTMapFinishSync(block, false, false)
+	if !ct.XSync {
+		t.Fatal("failed CT add was marked synchronized")
+	}
+
+	dpCTMapFinishSync(block, false, true)
+	if ct.XSync {
+		t.Fatal("successful CT add remained pending")
+	}
+}
+
+func TestDpCTMapFinishSyncDoesNotAcknowledgeNewerUpdate(t *testing.T) {
+	original := mh.dpEbpf
+	t.Cleanup(func() { mh.dpEbpf = original })
+
+	ct := &DpCtInfo{
+		DIP:    net.ParseIP("172.30.250.202"),
+		SIP:    net.ParseIP("192.168.64.2"),
+		Dport:  18081,
+		Sport:  50100,
+		Proto:  "tcp",
+		CState: "est",
+		NTs:    time.Unix(1, 0),
+		XSync:  true,
+	}
+	mh.dpEbpf = &DpEbpfH{ctMap: map[string]*DpCtInfo{ct.Key(): ct}}
+	block := []DpCtInfo{cloneDpCtInfo(ct)}
+
+	ct.NTs = time.Unix(2, 0)
+	dpCTMapFinishSync(block, false, true)
+	if !ct.XSync {
+		t.Fatal("an old RPC result acknowledged a newer CT update")
+	}
+}

--- a/pkg/loxinet/xsync_server.go
+++ b/pkg/loxinet/xsync_server.go
@@ -80,8 +80,8 @@ func (xs *XSync) DpWorkOnCtAdd(cti DpCtInfo, ret *int) error {
 	}
 
 	if cti.Proto == "xsync" {
-		mh.dp.SyncMtx.Lock()
-		defer mh.dp.SyncMtx.Unlock()
+		mh.dp.RemoteMtx.Lock()
+		defer mh.dp.RemoteMtx.Unlock()
 
 		for idx := range mh.dp.Remotes {
 			r := &mh.dp.Remotes[idx]
@@ -126,10 +126,11 @@ func (xs *XSync) DpWorkOnCtGet(async int, ret *int) error {
 		return errors.New("Not-Ready")
 	}
 
-	// Most likely need to reset reverse rpc channel
-	mh.dp.DpXsyncRPCReset()
-
 	tk.LogIt(tk.LogDebug, "RPC -  CT Get %d\n", async)
+	// Queue the reverse broadcast without resetting its RPC connection from
+	// inside this request handler. Resetting here needs the same client lock
+	// held by a simultaneous outbound CT Get and can make both peers wait for
+	// each other until the RPC timeout.
 	mh.dp.DpHooks.DpCtGetAsync()
 	*ret = 0
 


### PR DESCRIPTION
## Summary

Fixes #1130.

A two-node netRPC HA pair can enter a symmetric timeout/reset loop during bidirectional conntrack synchronization. The outbound path holds the RPC mutex while waiting on the peer, while inbound/full-sync paths can contend for the same mutex. CT update flushing also performs blocking RPC calls while holding the datapath CT mutex, which can block REST reads and local CT handling. Finally, the old batching path clears the pending XSync state before checking whether the block RPC succeeded, so a failed add is not retried.

## Changes

- Protect the remote-peer list with a dedicated RW mutex instead of sharing the blocking RPC mutex.
- Remove the synchronous RPC reset from the inbound CT-get handler.
- Make full-sync requests buffered, non-blocking, and coalescing.
- Snapshot eligible CT updates under the datapath mutex, then release it before network RPC.
- Clear XSync/delete state only after a successful block RPC; retain failed additions for retry.
- Add focused tests for non-blocking CT-get coalescing, RPC-result handling, and concurrent-update preservation.

## Validation

Targeted tests:

```text
go test ./pkg/loxinet -run 'TestDpCtGetAsyncCoalescesWithoutBlocking|TestDpCTMapFinishSyncUsesRPCResult|TestDpCTMapFinishSyncDoesNotAcknowledgeNewerUpdate' -count=1 -vet=off
ok github.com/loxilb-io/loxilb/pkg/loxinet
```

The patched binary was built into an ARM64 LoxiLB image and exercised on a two-node native netRPC HA testbed. Each trial waited for stable MASTER/BACKUP state, healthy endpoints, and connected XSync, then created one fixed TCP flow and polled CT state on both peers.

| Extra startup delay | MASTER first visible | BACKUP first visible | timeouts / failures / resets |
| ---: | ---: | ---: | ---: |
| 0 s | 1.008 s | 12.063 s | 0 / 0 / 0 |
| 5 s | 1.015 s | 12.065 s | 0 / 0 / 0 |
| 10 s | 1.012 s | 12.070 s | 0 / 0 / 0 |
| 20 s | 1.006 s | 17.114 s | 0 / 0 / 0 |

All four trials completed with successful client traffic, the expected full-NAT source address, CT visibility on both MASTER and BACKUP, and no XSync connection reset during the observation window.

The change was also applied cleanly on top of current `main` (`71982cd6`).