### PR TITLE
proto/bfd: deliver election results in the order they were decided

### DIFF
--- a/pkg/proto/bfd.go
+++ b/pkg/proto/bfd.go
@@ -101,6 +101,13 @@ type bfdSession struct {
 	Mutex          sync.RWMutex
 	Notify         Notifer
 	PktDat         [24]byte
+	// Election notifications are decided under Mutex and parked in ntfPending
+	// (latest wins). ntfSig wakes the per-session notifier goroutine, which is
+	// the only path that calls Notify. This keeps Notify (and any lock it takes)
+	// out of BFDMtx/Mutex and out of the ticker and listener goroutines.
+	ntfPending string
+	ntfSig     chan struct{}
+	ntfFin     chan struct{}
 }
 
 type Struct struct {
@@ -124,6 +131,7 @@ func (bs *Struct) BFDAddRemote(args ConfigArgs, cbs Notifer) error {
 	if sess != nil {
 		var update bool
 		if sess.Instance == args.Instance {
+			sess.Mutex.Lock()
 			if args.Interval != 0 && sess.DesMinTxInt != args.Interval {
 				sess.DesMinTxInt = args.Interval
 				sess.ReqMinRxInt = args.Interval
@@ -134,11 +142,14 @@ func (bs *Struct) BFDAddRemote(args ConfigArgs, cbs Notifer) error {
 				sess.MyMulti = args.Multi
 				update = true
 			}
+			sess.Mutex.Unlock()
 			if update {
 				sess.Fin <- true
 				sess.TxTicker.Stop()
 				sess.RxTicker.Stop()
+				sess.Mutex.Lock()
 				sess.State = BFDDown
+				sess.Mutex.Unlock()
 
 				sess.TxTicker = time.NewTicker(time.Duration(sess.DesMinTxInt) * time.Microsecond)
 				sess.RxTicker = time.NewTicker(time.Duration(BFDMinSysRXIntervalUs) * time.Microsecond)
@@ -198,9 +209,11 @@ func (bs *Struct) BFDGet() ([]cmn.BFDMod, error) {
 		temp.SourceIP = s.MyIP
 		port, _ := strconv.Atoi(pair[1])
 		temp.Port = uint16(port)
+		s.Mutex.RLock()
 		temp.Interval = uint64(s.DesMinTxInt)
 		temp.RetryCount = s.MyMulti
 		temp.State = BFDStateMap[uint8(s.State)]
+		s.Mutex.RUnlock()
 		res = append(res, temp)
 	}
 
@@ -275,11 +288,10 @@ func (bs *Struct) bfdStartListener(port uint16) error {
 }
 
 func (b *bfdSession) RunSessionSM(raw *WireRaw) {
-	inst := b.Instance
-	rem := b.RemoteName
-	oldState := b.State
-
 	b.Mutex.Lock()
+	defer b.Mutex.Unlock()
+
+	oldState := b.State
 
 	b.RemMulti = raw.Multi
 	b.RemDisc = raw.Disc
@@ -318,18 +330,15 @@ func (b *bfdSession) RunSessionSM(raw *WireRaw) {
 			}
 		}
 	}
-	newState := b.State
-	b.Mutex.Unlock()
 
-	b.sendStateNotification(newState, oldState, inst, rem)
+	b.electLocked(b.State, oldState)
 }
 
 func (b *bfdSession) checkSessTimeout() {
-	inst := b.Instance
-	rem := b.RemoteName
-	oldState := b.State
-
 	b.Mutex.Lock()
+	defer b.Mutex.Unlock()
+
+	oldState := b.State
 	if b.State == BFDUp {
 		if time.Duration(time.Since(b.LastRxTS).Microseconds()) > time.Duration(b.TimeOut) {
 			b.State = BFDDown
@@ -337,33 +346,63 @@ func (b *bfdSession) checkSessTimeout() {
 			tk.LogIt(tk.LogInfo, "%s: BFD State -> Down (%v:%v)\n", b.RemoteName, b.MyDisc, b.RemDisc)
 		}
 	}
-	newState := b.State
-	b.Mutex.Unlock()
 
-	b.sendStateNotification(newState, oldState, inst, rem)
+	b.electLocked(b.State, oldState)
 }
 
-func (b *bfdSession) sendStateNotification(newState, oldState SessionState, inst string, remote string) {
+// electLocked decides the cluster role for a session-state transition, records
+// it in CiState and queues it for the notifier goroutine. The decision, the
+// CiState write and the queueing happen in one critical section so that the
+// order in which notifications are delivered is the order in which they were
+// decided. Must be called with b.Mutex held for writing.
+func (b *bfdSession) electLocked(newState, oldState SessionState) {
 	if newState == oldState || b.RemDisc == 0 {
 		return
 	}
 
+	var ciState string
 	if newState == BFDUp {
-		ciState := cmn.CIBackupStateString
+		ciState = cmn.CIBackupStateString
 		if b.MyDisc > b.RemDisc {
 			ciState = cmn.CIMasterStateString
 		}
 		tk.LogIt(tk.LogInfo, "%s: State change (%v:%v)\n", b.RemoteName, b.MyDisc, b.RemDisc)
-		b.CiState = ciState
-		b.Notify.BFDSessionNotify(inst, remote, ciState)
 	} else if newState == BFDDown && oldState == BFDUp {
-		ciState := cmn.CIMasterStateString
-		b.CiState = ciState
-		b.Notify.BFDSessionNotify(inst, remote, ciState)
+		ciState = cmn.CIMasterStateString
 	} else if b.RemDisc == b.MyDisc {
-		ciState := cmn.CIUnDefStateString
-		b.CiState = ciState
-		b.Notify.BFDSessionNotify(inst, remote, ciState)
+		ciState = cmn.CIUnDefStateString
+	} else {
+		return
+	}
+
+	b.CiState = ciState
+	b.ntfPending = ciState
+	select {
+	case b.ntfSig <- struct{}{}:
+	default:
+		// notifier already signalled; it will pick up the latest value
+	}
+}
+
+// bfdSessionNotifier delivers queued election results to Notify, one at a
+// time and in decision order. It runs per session and is the only goroutine
+// that calls Notify, so callers of Notify never hold BFDMtx or b.Mutex.
+func (b *bfdSession) bfdSessionNotifier() {
+	for {
+		select {
+		case <-b.ntfFin:
+			return
+		case <-b.ntfSig:
+		}
+
+		b.Mutex.Lock()
+		ciState := b.ntfPending
+		b.ntfPending = ""
+		b.Mutex.Unlock()
+
+		if ciState != "" {
+			b.Notify.BFDSessionNotify(b.Instance, b.RemoteName, ciState)
+		}
 	}
 }
 
@@ -450,16 +489,22 @@ func (b *bfdSession) initialize(remoteIP string, sourceIP string, port uint16, i
 	}
 
 	b.Fin = make(chan bool)
+	b.ntfSig = make(chan struct{}, 1)
+	b.ntfFin = make(chan struct{})
 	b.TxTicker = time.NewTicker(time.Duration(b.DesMinTxInt) * time.Microsecond)
 	b.RxTicker = time.NewTicker(time.Duration(BFDMinSysRXIntervalUs) * time.Microsecond)
 
+	go b.bfdSessionNotifier()
 	go b.bfdSessionTicker()
 	return nil
 }
 
 func (b *bfdSession) destruct() {
+	b.Mutex.Lock()
 	b.State = BFDAdminDown
+	b.Mutex.Unlock()
 	b.Fin <- true
+	close(b.ntfFin)
 	b.TxTicker.Stop()
 	b.RxTicker.Stop()
 	// Signal ADMIN Down to peer
@@ -468,6 +513,8 @@ func (b *bfdSession) destruct() {
 }
 
 func (b *bfdSession) encodeCtrlPacket() error {
+	b.Mutex.RLock()
+	defer b.Mutex.RUnlock()
 
 	b.PktDat[0] = byte(byte(0x1<<5) | byte(0))
 	b.PktDat[1] = (uint8(b.State) << 6)

--- a/pkg/proto/bfd_test.go
+++ b/pkg/proto/bfd_test.go
@@ -1,0 +1,195 @@
+package bfd
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	cmn "github.com/loxilb-io/loxilb/common"
+)
+
+// recNotifier records deliveries. It takes the session mutex on every
+// delivery, so if the notifier ever called it with that mutex held the
+// test would self-deadlock and time out.
+type recNotifier struct {
+	sess   *bfdSession
+	mu     sync.Mutex
+	states []string
+}
+
+func (n *recNotifier) BFDSessionNotify(_ string, _ string, state string) {
+	if n.sess != nil {
+		n.sess.Mutex.Lock()
+		n.sess.Mutex.Unlock()
+	}
+	n.mu.Lock()
+	n.states = append(n.states, state)
+	n.mu.Unlock()
+}
+
+func (n *recNotifier) snapshot() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return append([]string(nil), n.states...)
+}
+
+func newTestSession(t *testing.T, myDisc uint32) (*bfdSession, *recNotifier) {
+	t.Helper()
+	b := &bfdSession{
+		Instance:   cmn.CIDefault,
+		RemoteName: "127.0.0.1:3784",
+		State:      BFDDown,
+		MyDisc:     myDisc,
+		MyMulti:    1,
+		Fin:        make(chan bool),
+		ntfSig:     make(chan struct{}, 1),
+		ntfFin:     make(chan struct{}),
+	}
+	n := &recNotifier{sess: b}
+	b.Notify = n
+	go b.bfdSessionNotifier()
+	t.Cleanup(func() { close(b.ntfFin) })
+	return b, n
+}
+
+func waitDrained(t *testing.T, b *bfdSession, n *recNotifier) []string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		b.Mutex.RLock()
+		pending := b.ntfPending
+		b.Mutex.RUnlock()
+		if pending == "" && len(b.ntfSig) == 0 {
+			// give the notifier a moment to finish an in-flight delivery
+			before := len(n.snapshot())
+			time.Sleep(20 * time.Millisecond)
+			if len(n.snapshot()) == before {
+				return n.snapshot()
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("notifier did not drain")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestElectionNotifyOrder hammers the listener path (RunSessionSM), the
+// timeout path (checkSessTimeout) and the transmit path (encodeCtrlPacket)
+// concurrently. Under -race this catches unlocked access; the assertion
+// checks that the last delivered role is the role the session believes it
+// has, which is the invariant that keeps force-reelection working.
+func TestElectionNotifyOrder(t *testing.T) {
+	const myDisc = 1000
+	b, n := newTestSession(t, myDisc)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// listener: peer flips between a lower and a higher discriminator
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			disc := uint32(myDisc - 1)
+			if i%2 == 1 {
+				disc = myDisc + 1
+			}
+			// DesMinTxInt=1 with Multi=1 makes the timeout path fire on
+			// almost every tick without sleeping in the test.
+			b.RunSessionSM(&WireRaw{State: BFDUp, Multi: 1, Disc: disc, DesMinTxInt: 1})
+			i++
+		}
+	}()
+
+	// timeout path
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			b.checkSessTimeout()
+		}
+	}()
+
+	// transmit path
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			b.encodeCtrlPacket()
+		}
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	states := waitDrained(t, b, n)
+	if len(states) == 0 {
+		t.Fatalf("no notifications delivered")
+	}
+	b.Mutex.RLock()
+	ciState := b.CiState
+	b.Mutex.RUnlock()
+	last := states[len(states)-1]
+	if last != ciState {
+		t.Fatalf("last delivered %q but session CiState %q (%d deliveries)", last, ciState, len(states))
+	}
+	for _, st := range states {
+		switch st {
+		case cmn.CIMasterStateString, cmn.CIBackupStateString, cmn.CIUnDefStateString:
+		default:
+			t.Fatalf("unexpected state %q", st)
+		}
+	}
+}
+
+// TestElectionLatestWins queues several decisions while the notifier is
+// blocked and checks that the final role is delivered and the queueing
+// path never blocks the caller.
+func TestElectionLatestWins(t *testing.T) {
+	b, n := newTestSession(t, 1000)
+
+	// Block the notifier by holding the mutex it needs to read the mailbox.
+	b.Mutex.Lock()
+	b.RemDisc = 2000
+	b.electLocked(BFDUp, BFDDown) // BACKUP
+	b.electLocked(BFDDown, BFDUp) // MASTER
+	b.electLocked(BFDUp, BFDDown) // BACKUP (latest)
+	b.Mutex.Unlock()
+
+	states := waitDrained(t, b, n)
+	if len(states) != 1 || states[0] != cmn.CIBackupStateString {
+		t.Fatalf("expected single coalesced BACKUP delivery, got %v", states)
+	}
+	if b.CiState != cmn.CIBackupStateString {
+		t.Fatalf("CiState %q", b.CiState)
+	}
+}
+
+// TestElectionSkipsWhenRemoteUnknown checks the RemDisc==0 guard.
+func TestElectionSkipsWhenRemoteUnknown(t *testing.T) {
+	b, n := newTestSession(t, 1000)
+	b.Mutex.Lock()
+	b.electLocked(BFDUp, BFDDown)
+	b.Mutex.Unlock()
+	if states := waitDrained(t, b, n); len(states) != 0 {
+		t.Fatalf("expected no delivery, got %v", states)
+	}
+}


### PR DESCRIPTION
## What

BFD election results are now decided, recorded and queued inside one `b.Mutex` critical section, and delivered to `BFDSessionNotify` by a per-session notifier goroutine in the order they were decided. The listener and ticker goroutines no longer call `Notify` (and so never wait for `mh.mtx`).

## Why

After a joint cold restart both nodes could settle on MASTER and stay there until the next real transition (seen once in about fifteen joint restarts in #1129's case 7, which added a harness recovery path for it).

The session has two notification paths on different goroutines: `RunSessionSM` (listener, called with `BFDMtx` held) and `checkSessTimeout` (ticker). Each released `b.Mutex` and then, with no lock at all, decided the role, wrote `b.CiState` and called `Notify`, which takes `mh.mtx`. `BFDSessionNotify` does not decide anything; it stores whatever string arrives, so the applied order is the `mh.mtx` acquisition order rather than the decision order.

The stuck state needs one specific interleaving: the timeout path decides MASTER, the receive path decides BACKUP right after (its `b.CiState` write lands last), and the two then take `mh.mtx` in the opposite order. The session ends up believing BACKUP while CIStateH records MASTER. Force re-election in `RunSessionSM` only runs when the session believes it is MASTER, so nothing ever corrects it. Plain discriminator divergence cannot do this: `RemDisc` is refreshed on every packet and re-election converges. It is also a data race on `b.CiState`, `MyDisc` and `RemDisc`.

Two lock-order inversions existed alongside it and are removed by the same change:

- `processBFD` held `BFDMtx` while the notification took `mh.mtx`; the BFD add/del API and the `BFDconfig.txt` path take `mh.mtx` and then `BFDMtx`.
- The unbuffered `Fin` send in the `BFDAddRemote` update branch runs with `mh.mtx` held and could wait on a ticker goroutine that was itself waiting for `mh.mtx` inside a notification.

Neither is hit by the `--ka` flag path (it adds the session from a goroutine without `mh.mtx`).

## The fix

- `electLocked` replaces `sendStateNotification`: same decision rules, but run under `b.Mutex` together with the `b.CiState` write and the mailbox store.
- One-slot latest-wins mailbox per session, capacity-1 signal channel, non-blocking send. `bfdSessionNotifier` is the only goroutine that calls `Notify`; it holds neither `BFDMtx` nor `b.Mutex` while doing so. Started in `initialize`, stopped in `destruct`.
- Remaining unlocked reads moved under the lock: `oldState` at the top of both paths, `encodeCtrlPacket`, `BFDGet`, and the writes in the `BFDAddRemote` update branch and `destruct`.
- `cluster.go` is unchanged.

**Visible change:** a MASTER->BACKUP->MASTER flap that lands inside one notifier turn is delivered as a single MASTER. The intermediate state's VIP bind/unbind, `ka_hook`, BGP and firewall updates are skipped. The final state is always delivered (`CIStateUpdate` already ignores a same-state update).

## Reproduction and verification (cicd/sctpmh-seagull VM, 12 vCPU)

Both loxilbs killed with `kill -9` and relaunched together, both nodes' `cistate`/`bfd` APIs polled every second, no harness recovery path. STUCK = both MASTER for 40s or more; the pre-fix transient dual-MASTER lasts under a few seconds and self-corrects. "mh.mtx load" = netlink churn (dummy link addr/route add/del) and LB rule add/del via `loxicmd` on both nodes during the election window, plus 24 busy loops on the VM.

| binary | condition | restarts | stuck | BFD timeouts over the series |
|---|---|---|---|---|
| stock `ghcr.io/loxilb-io/loxilb:latest` | CPU pressure only | 20 | 0 | 2-4 per restart |
| stock | CPU pressure + mh.mtx load | 30 | **3** | 279 |
| this branch | CPU pressure + mh.mtx load | 30 | **0** | 5 |

All three stuck restarts carry the signature: the stuck node's last logged decision (`State change (my:rem)`) is BACKUP while the API reports MASTER for over 40s. CPU pressure alone opened the race window every time (several spurious timeouts per restart) but never produced the reorder; contention on `mh.mtx` is what does.

The drop in BFD timeouts (279 to 5) is a side effect worth noting: before, the ticker (which also transmits) and the listener stalled behind `mh.mtx` inside a notification, so keepalives stopped flowing under load and the peer timed out, which fed the flapping.

Unit test: `TestElectionNotifyOrder` runs the listener, timeout and transmit paths concurrently and checks that the last delivered role equals the session's own and that `Notify` is never called with `b.Mutex` held. The same load on the previous `bfd.go` reports seven data races under `go test -race` (including `sendStateNotification`); this branch reports none. `go test -race -count=5 ./pkg/proto/` passes.

Refs #1129 (the harness recovery path in `restart_loxilbs_together` can be dropped once this is in).
