### PR TITLE
loxinet: apply cluster state changes from one worker, under mh.mtx

### DIFF
--- a/pkg/loxinet/cisync_test.go
+++ b/pkg/loxinet/cisync_test.go
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2022 NetLOX Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loxinet
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	cmn "github.com/loxilb-io/loxilb/common"
+)
+
+// The cluster sync worker and RulesApplyClusterState are exercised without
+// the datapath: the worker takes its apply and hook functions as arguments,
+// and RulesApplyClusterState only needs mh.has, mh.cloudHook and an empty
+// RuleH.
+
+const testInst = "sync-test"
+
+// ciTestSetState - what a BFD notification or the API does: a state change
+// recorded under mh.mtx
+func ciTestSetState(ch *CIStateH, inst, state string) {
+	mh.mtx.Lock()
+	defer mh.mtx.Unlock()
+	ch.CIStateUpdate(cmn.HASMod{Instance: inst, State: state, Vip: net.IPv4zero})
+}
+
+// syncRecorder - collects what the worker applied and hooked
+type syncRecorder struct {
+	mx      sync.Mutex
+	applied []string
+	hooked  []string
+	fail    int // how many of the next applies report an abandoned pass
+	ch      *CIStateH
+}
+
+func (r *syncRecorder) apply(inst string) (string, net.IP, bool) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	if r.fail > 0 {
+		r.fail--
+		return "", nil, false
+	}
+	state, vip := r.ch.CIStateVipGetInst(inst)
+	r.applied = append(r.applied, state)
+	return state, vip, true
+}
+
+func (r *syncRecorder) hook(_, state, _ string) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	r.hooked = append(r.hooked, state)
+}
+
+func (r *syncRecorder) snapshot() (applied, hooked []string) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	return append([]string(nil), r.applied...), append([]string(nil), r.hooked...)
+}
+
+// waitFor - poll until cond holds or the deadline passes
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func startTestWorker(t *testing.T) (*CIStateH, *syncRecorder) {
+	t.Helper()
+	ch := CIInit(CIKAArgs{})
+	rec := &syncRecorder{ch: ch}
+	go ch.ciSyncWorker(rec.apply, rec.hook)
+	t.Cleanup(func() { ch.syncOnce.Do(func() { close(ch.syncFin) }) })
+	return ch, rec
+}
+
+// A burst of transitions from several goroutines: whatever the worker applied
+// last is the live state, and the hook saw every change of the applied state
+// exactly once, in order.
+func TestCISyncWorkerAppliesLiveState(t *testing.T) {
+	ch, rec := startTestWorker(t)
+
+	states := []string{cmn.CIMasterStateString, cmn.CIBackupStateString}
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				ciTestSetState(ch, testInst, states[(g+i)%2])
+			}
+		}(g)
+	}
+	wg.Wait()
+	// Settle on a known final state.
+	ciTestSetState(ch, testInst, cmn.CIMasterStateString)
+
+	waitFor(t, "final state applied", func() bool {
+		applied, _ := rec.snapshot()
+		return len(applied) > 0 && applied[len(applied)-1] == cmn.CIMasterStateString
+	})
+	// Give any straggler a chance to show up, then check the worker is quiet.
+	time.Sleep(50 * time.Millisecond)
+
+	applied, hooked := rec.snapshot()
+	live, _ := ch.CIStateGetInst(testInst)
+	if applied[len(applied)-1] != live {
+		t.Fatalf("last applied %s, live state %s", applied[len(applied)-1], live)
+	}
+	if len(applied) > 202 {
+		t.Fatalf("%d applies for 201 transitions: the worker is not collapsing", len(applied))
+	}
+	if len(hooked) == 0 || hooked[len(hooked)-1] != live {
+		t.Fatalf("hook last saw %v, live state %s", hooked, live)
+	}
+	for i := 1; i < len(hooked); i++ {
+		if hooked[i] == hooked[i-1] {
+			t.Fatalf("hook called twice in a row with %s: %v", hooked[i], hooked)
+		}
+	}
+}
+
+// Marks that land while the worker is busy collapse into one pass, and the
+// same applied state is not hooked again.
+func TestCISyncWorkerCollapsesAndDedupesHook(t *testing.T) {
+	ch, rec := startTestWorker(t)
+
+	ciTestSetState(ch, testInst, cmn.CIMasterStateString)
+	waitFor(t, "first apply", func() bool { a, _ := rec.snapshot(); return len(a) == 1 })
+
+	// A flip and flip-back: two dirty marks, at most two applies, the hook
+	// sees MASTER once more only if BACKUP was applied in between.
+	ciTestSetState(ch, testInst, cmn.CIBackupStateString)
+	ciTestSetState(ch, testInst, cmn.CIMasterStateString)
+	waitFor(t, "flip-back applied", func() bool {
+		a, _ := rec.snapshot()
+		return len(a) >= 2 && a[len(a)-1] == cmn.CIMasterStateString
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	applied, hooked := rec.snapshot()
+	if len(applied) > 3 {
+		t.Fatalf("applied %v for three transitions", applied)
+	}
+	for i := 1; i < len(hooked); i++ {
+		if hooked[i] == hooked[i-1] {
+			t.Fatalf("hook not deduplicated: %v", hooked)
+		}
+	}
+	if hooked[len(hooked)-1] != cmn.CIMasterStateString {
+		t.Fatalf("hook last saw %v", hooked)
+	}
+}
+
+// An abandoned pass is not hooked, and the instance is applied on the next
+// mark.
+func TestCISyncWorkerAbandonedPass(t *testing.T) {
+	ch, rec := startTestWorker(t)
+
+	rec.mx.Lock()
+	rec.fail = 1
+	rec.mx.Unlock()
+
+	ciTestSetState(ch, testInst, cmn.CIMasterStateString)
+	time.Sleep(50 * time.Millisecond)
+	applied, hooked := rec.snapshot()
+	if len(applied) != 0 || len(hooked) != 0 {
+		t.Fatalf("abandoned pass was applied %v / hooked %v", applied, hooked)
+	}
+
+	// The flip that forced the abandonment re-marks the instance.
+	ciTestSetState(ch, testInst, cmn.CIBackupStateString)
+	waitFor(t, "apply after abandoned pass", func() bool { a, _ := rec.snapshot(); return len(a) == 1 })
+	applied, hooked = rec.snapshot()
+	if applied[0] != cmn.CIBackupStateString || len(hooked) != 1 || hooked[0] != cmn.CIBackupStateString {
+		t.Fatalf("applied %v hooked %v", applied, hooked)
+	}
+}
+
+// Same-state and invalid updates neither change nor queue anything.
+func TestCIStateUpdateNoOpCases(t *testing.T) {
+	ch := CIInit(CIKAArgs{})
+
+	if _, err := ch.CIStateUpdate(cmn.HASMod{Instance: testInst, State: cmn.CIMasterStateString, Vip: net.IPv4zero}); err != nil {
+		t.Fatal(err)
+	}
+	ch.mx.Lock()
+	delete(ch.syncDirty, testInst)
+	ch.mx.Unlock()
+	<-ch.syncSig
+
+	if _, err := ch.CIStateUpdate(cmn.HASMod{Instance: testInst, State: cmn.CIMasterStateString, Vip: net.IPv4zero}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ch.CIStateUpdate(cmn.HASMod{Instance: testInst, State: "NO_SUCH_STATE", Vip: net.IPv4zero}); err == nil {
+		t.Fatal("invalid state accepted")
+	}
+	ch.mx.Lock()
+	_, dirty := ch.syncDirty[testInst]
+	ch.mx.Unlock()
+	if dirty {
+		t.Fatal("no-op update queued the instance")
+	}
+	select {
+	case <-ch.syncSig:
+		t.Fatal("no-op update signalled the worker")
+	default:
+	}
+	if st, _ := ch.CIStateGetInst(testInst); st != cmn.CIMasterStateString {
+		t.Fatalf("state changed to %s", st)
+	}
+}
+
+// testCloudHook - counts prepare and unprepare calls and can make prepare
+// fail
+type testCloudHook struct {
+	prepares, unprepares int
+	prepareErr           error
+}
+
+func (c *testCloudHook) CloudAPIInit(string) error { return nil }
+func (c *testCloudHook) CloudPrepareVIPNetWork() error {
+	c.prepares++
+	return c.prepareErr
+}
+func (c *testCloudHook) CloudUnPrepareVIPNetWork() error { c.unprepares++; return nil }
+func (c *testCloudHook) CloudDestroyVIPNetWork() error   { return nil }
+func (c *testCloudHook) CloudUpdatePrivateIP(net.IP, net.IP, bool) error {
+	return nil
+}
+func (c *testCloudHook) CloudGetPrivateInterfaceID() (int, error) { return 0, nil }
+
+// withApplyFixture - point mh.has and mh.cloudHook at test doubles for the
+// duration of the test
+func withApplyFixture(t *testing.T, hook *testCloudHook) (*CIStateH, *RuleH) {
+	t.Helper()
+	savedHas, savedHook := mh.has, mh.cloudHook
+	ch := CIInit(CIKAArgs{})
+	mh.has = ch
+	mh.cloudHook = hook
+	t.Cleanup(func() { mh.has, mh.cloudHook = savedHas, savedHook })
+	return ch, new(RuleH)
+}
+
+// Promoted between the first read and the locked section, with the cloud
+// network not prepared: the pass starts over so that prepare runs first.
+func TestRulesApplyClusterStateRestartsOnPromotion(t *testing.T) {
+	hook := &testCloudHook{}
+	ch, R := withApplyFixture(t, hook)
+	ciTestSetState(ch, cmn.CIDefault, cmn.CIBackupStateString)
+
+	seams := 0
+	R.applyTestSeam = func() {
+		seams++
+		if seams == 1 {
+			ciTestSetState(ch, cmn.CIDefault, cmn.CIMasterStateString)
+		}
+	}
+
+	state, _, ok := R.RulesApplyClusterState(cmn.CIDefault)
+	if !ok || state != cmn.CIMasterStateString {
+		t.Fatalf("applied %q ok=%v", state, ok)
+	}
+	if seams != 2 {
+		t.Fatalf("pass ran %d times, want 2", seams)
+	}
+	if hook.prepares != 1 || !R.cloudPrepared {
+		t.Fatalf("prepares %d cloudPrepared %v", hook.prepares, R.cloudPrepared)
+	}
+}
+
+// A failed prepare is tried once per promotion: the pass goes on and does not
+// restart.
+func TestRulesApplyClusterStatePrepareFailsOnce(t *testing.T) {
+	hook := &testCloudHook{prepareErr: errors.New("aws down")}
+	ch, R := withApplyFixture(t, hook)
+	ciTestSetState(ch, cmn.CIDefault, cmn.CIMasterStateString)
+
+	seams := 0
+	R.applyTestSeam = func() { seams++ }
+
+	state, _, ok := R.RulesApplyClusterState(cmn.CIDefault)
+	if !ok || state != cmn.CIMasterStateString {
+		t.Fatalf("applied %q ok=%v", state, ok)
+	}
+	if seams != 1 || hook.prepares != 1 || R.cloudPrepared {
+		t.Fatalf("passes %d prepares %d cloudPrepared %v", seams, hook.prepares, R.cloudPrepared)
+	}
+}
+
+// A promotion that happens while already prepared does not restart, a
+// demotion unprepares once, and a second demotion pass does nothing.
+func TestRulesApplyClusterStatePrepareUnprepareOnce(t *testing.T) {
+	hook := &testCloudHook{}
+	ch, R := withApplyFixture(t, hook)
+
+	ciTestSetState(ch, cmn.CIDefault, cmn.CIMasterStateString)
+	if _, _, ok := R.RulesApplyClusterState(cmn.CIDefault); !ok || hook.prepares != 1 {
+		t.Fatalf("first promotion: ok=%v prepares %d", ok, hook.prepares)
+	}
+	// Already prepared: a flip-back between the reads must not restart.
+	ciTestSetState(ch, cmn.CIDefault, cmn.CIBackupStateString)
+	seams := 0
+	R.applyTestSeam = func() {
+		seams++
+		if seams == 1 {
+			ciTestSetState(ch, cmn.CIDefault, cmn.CIMasterStateString)
+		}
+	}
+	if state, _, _ := R.RulesApplyClusterState(cmn.CIDefault); state != cmn.CIMasterStateString || seams != 1 || hook.prepares != 1 {
+		t.Fatalf("flip-back: state %s passes %d prepares %d", state, seams, hook.prepares)
+	}
+	R.applyTestSeam = nil
+
+	ciTestSetState(ch, cmn.CIDefault, cmn.CIBackupStateString)
+	R.RulesApplyClusterState(cmn.CIDefault)
+	R.RulesApplyClusterState(cmn.CIDefault)
+	if hook.unprepares != 1 || R.cloudPrepared {
+		t.Fatalf("unprepares %d cloudPrepared %v", hook.unprepares, R.cloudPrepared)
+	}
+}
+
+// Instances other than the default never touch the cloud hook.
+func TestRulesApplyClusterStateNonDefaultSkipsCloud(t *testing.T) {
+	hook := &testCloudHook{}
+	ch, R := withApplyFixture(t, hook)
+	ciTestSetState(ch, testInst, cmn.CIMasterStateString)
+
+	state, _, ok := R.RulesApplyClusterState(testInst)
+	if !ok || state != cmn.CIMasterStateString || hook.prepares != 0 {
+		t.Fatalf("state %s ok=%v prepares %d", state, ok, hook.prepares)
+	}
+}

--- a/pkg/loxinet/cluster.go
+++ b/pkg/loxinet/cluster.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	nlp "github.com/loxilb-io/loxilb/api/loxinlp"
@@ -90,6 +91,24 @@ type CIStateH struct {
 	OSrc6       string
 	initRules   bool
 	initRules6  bool
+
+	// mx guards ClusterMap, the fields of its entries and the sync mailbox
+	// below. It nests inside mh.mtx (mh.mtx -> mx); nothing takes the two the
+	// other way round, and nothing calls out of this package while holding
+	// it. Readers that only want the state of an instance take it shared, so
+	// they no longer need mh.mtx for that.
+	mx sync.RWMutex
+
+	// Cluster state changes are not applied by the caller of CIStateUpdate.
+	// The caller records the instance in syncDirty and wakes the sync worker
+	// (CIStartSync) through syncSig; the worker applies the state the
+	// instance is in when it gets to it. Overlapping transitions collapse
+	// into their final value, in the order they were decided, and nothing is
+	// applied from a stale copy of the state.
+	syncDirty map[string]struct{}
+	syncSig   chan struct{}
+	syncFin   chan struct{}
+	syncOnce  sync.Once
 }
 
 func (ch *CIStateH) BFDSessionNotify(instance string, _ string, ciState string) {
@@ -151,12 +170,36 @@ func (ch *CIStateH) CISpawn() {
 
 // CIStateGetInst - routine to get HA state
 func (ch *CIStateH) CIStateGetInst(inst string) (string, error) {
+	ch.mx.RLock()
+	defer ch.mx.RUnlock()
 
 	if ci, ok := ch.ClusterMap[inst]; ok {
 		return ci.StateStr, nil
 	}
 
 	return cmn.CIUnDefStateString, errors.New("not found")
+}
+
+// CIStateVipGetInst - the HA state of an instance together with its VIP,
+// read in one go so the pair is consistent
+func (ch *CIStateH) CIStateVipGetInst(inst string) (string, net.IP) {
+	ch.mx.RLock()
+	defer ch.mx.RUnlock()
+
+	if ci, ok := ch.ClusterMap[inst]; ok {
+		return ci.StateStr, ci.Vip
+	}
+
+	return cmn.CIUnDefStateString, net.IPv4zero
+}
+
+// ciInstExists - whether a cluster instance is known
+func (ch *CIStateH) ciInstExists(inst string) bool {
+	ch.mx.RLock()
+	defer ch.mx.RUnlock()
+
+	_, found := ch.ClusterMap[inst]
+	return found
 }
 
 // CIInit - routine to initialize Cluster context
@@ -173,6 +216,12 @@ func CIInit(args CIKAArgs) *CIStateH {
 	nCIh.SourceIP = args.SourceIP
 	nCIh.Interval = args.Interval
 	nCIh.ClusterMap = make(map[string]*ClusterInstance)
+	// The mailbox exists from the start so that CIDestroy can always close it;
+	// the worker itself is started later by CIStartSync, once the zones it
+	// applies state to exist.
+	nCIh.syncDirty = make(map[string]struct{})
+	nCIh.syncSig = make(chan struct{}, 1)
+	nCIh.syncFin = make(chan struct{})
 
 	if _, ok := nCIh.ClusterMap[cmn.CIDefault]; !ok {
 		ci := &ClusterInstance{State: cmn.CIStateNotDefined,
@@ -284,6 +333,7 @@ func CIInit(args CIKAArgs) *CIStateH {
 
 // CIDestroy - routine to destroy Cluster context
 func (ch *CIStateH) CIDestroy() {
+	ch.syncOnce.Do(func() { close(ch.syncFin) })
 
 	if ch.ClusterIf != "" {
 		tk.LogIt(tk.LogError, "cluster-dev name\n")
@@ -486,6 +536,9 @@ func (ch *CIStateH) CIAddClusterRoute(dest string, add bool) {
 func (ch *CIStateH) CIStateGet() ([]cmn.HASMod, error) {
 	var res []cmn.HASMod
 
+	ch.mx.RLock()
+	defer ch.mx.RUnlock()
+
 	for i, s := range ch.ClusterMap {
 		var temp cmn.HASMod
 		temp.Instance = i
@@ -498,6 +551,9 @@ func (ch *CIStateH) CIStateGet() ([]cmn.HASMod, error) {
 
 // CIVipGet - routine to get HA state
 func (ch *CIStateH) CIVipGet(inst string) (net.IP, error) {
+	ch.mx.RLock()
+	defer ch.mx.RUnlock()
+
 	if ci, ok := ch.ClusterMap[inst]; ok {
 		if ci.Vip != nil && !ci.Vip.IsUnspecified() {
 			return ci.Vip, nil
@@ -512,57 +568,124 @@ func (ch *CIStateH) IsCIKAMode() bool {
 }
 
 // CIStateUpdate - routine to update cluster state
+//
+// Called with mh.mtx held. It records the new state and queues the instance
+// for the sync worker; it does not apply the state itself, and it never
+// blocks on the worker.
 func (ch *CIStateH) CIStateUpdate(cm cmn.HASMod) (int, error) {
 
-	if _, ok := ch.ClusterMap[cm.Instance]; !ok {
-		ch.ClusterMap[cm.Instance] = &ClusterInstance{State: cmn.CIStateNotDefined,
+	ch.mx.Lock()
+	ci, found := ch.ClusterMap[cm.Instance]
+	if !found {
+		ci = &ClusterInstance{State: cmn.CIStateNotDefined,
 			StateStr: cmn.CIUnDefStateString,
 			Vip:      net.IPv4zero}
+		ch.ClusterMap[cm.Instance] = ci
 		tk.LogIt(tk.LogDebug, "[CLUSTER] New Instance %s created\n", cm.Instance)
 	}
 
-	ci, found := ch.ClusterMap[cm.Instance]
-	if !found {
-		tk.LogIt(tk.LogError, "[CLUSTER] New Instance %s find error\n", cm.Instance)
-		return -1, errors.New("cluster instance not found")
-	}
-
 	if ci.StateStr == cm.State {
-		return ci.State, nil
+		state := ci.State
+		ch.mx.Unlock()
+		return state, nil
 	}
 
-	if _, ok := ch.StateMap[cm.State]; ok {
-		tk.LogIt(tk.LogDebug, "[CLUSTER] Instance %s Current State %s Updated State: %s VIP : %s\n",
-			cm.Instance, ci.StateStr, cm.State, cm.Vip.String())
-		ci.StateStr = cm.State
-		ci.State = ch.StateMap[cm.State]
-		ci.Vip = cm.Vip
+	newState, ok := ch.StateMap[cm.State]
+	if !ok {
+		state := ci.State
+		ch.mx.Unlock()
+		tk.LogIt(tk.LogError, "[CLUSTER] Invalid State: %s\n", cm.State)
+		return state, errors.New("invalid cluster-state")
+	}
 
-		if mh.bgp != nil {
-			mh.bgp.UpdateCIState(cm.Instance, ci.State, ci.Vip)
+	tk.LogIt(tk.LogDebug, "[CLUSTER] Instance %s Current State %s Updated State: %s VIP : %s\n",
+		cm.Instance, ci.StateStr, cm.State, cm.Vip.String())
+	ci.StateStr = cm.State
+	ci.State = newState
+	ci.Vip = cm.Vip
+	state, vip := ci.State, ci.Vip
+	ch.syncDirty[cm.Instance] = struct{}{}
+	ch.mx.Unlock()
+
+	// UpdateCIState reads the state back through CIStateGetInst, so it must
+	// run after mx is released.
+	if mh.bgp != nil {
+		mh.bgp.UpdateCIState(cm.Instance, state, vip)
+	}
+
+	select {
+	case ch.syncSig <- struct{}{}:
+	default:
+		// worker already signalled; it drains syncDirty as a whole
+	}
+	return state, nil
+}
+
+// CIStartSync - start the goroutine that applies cluster state changes
+//
+// Called once the zones exist: the worker applies state to mh.zr. Changes
+// recorded before this point wait in the mailbox and are applied as soon as
+// the worker runs.
+func (ch *CIStateH) CIStartSync() {
+	go ch.ciSyncWorker(
+		func(inst string) (string, net.IP, bool) { return mh.zr.Rules.RulesApplyClusterState(inst) },
+		ciRunKAHook)
+}
+
+// ciSyncWorker - apply queued cluster state changes, one instance at a time
+//
+// apply brings an instance in line with its current state and returns what
+// it applied; hook is told about it afterwards. Both run outside every lock
+// of this package. The dirty set is taken as a whole before any instance is
+// applied, so a state change that lands while an instance is being applied
+// is never lost: it marks the instance again and wakes the worker for
+// another pass. An abandoned pass (apply returns false) relies on exactly
+// that.
+func (ch *CIStateH) ciSyncWorker(apply func(string) (string, net.IP, bool), hook func(inst, state, vip string)) {
+	// The hook is only told about a change of the state applied: a pass that
+	// re-applies the same state after a flip-back, or after an abandoned
+	// pass, is idempotent for the rules but would run the script twice.
+	lastHooked := make(map[string]string)
+
+	for {
+		select {
+		case <-ch.syncFin:
+			return
+		case <-ch.syncSig:
 		}
-		go mh.zr.Rules.RulesSyncToClusterState(cm.Instance, cm.State)
 
-		// Update Call the ka_hook.sh script
-		hookScrptCall := func(cm cmn.HASMod) {
-			if _, err := os.Stat(cmn.KAHookScript); !errors.Is(err, os.ErrNotExist) {
-				command := cmn.KAHookScript + " " + cm.Instance + " " + cm.State + " " + ci.Vip.String()
-				cmd := exec.Command("bash", "-c", command)
-				output, err := cmd.Output()
-				if err != nil {
-					tk.LogIt(tk.LogError, "[CLUSTER] Error in applying ka hook : %s", err.Error())
-				} else {
-					tk.LogIt(tk.LogDebug, "[CLUSTER] ka hook output: %v\n", string(output))
-				}
+		ch.mx.Lock()
+		dirty := ch.syncDirty
+		ch.syncDirty = make(map[string]struct{})
+		ch.mx.Unlock()
+
+		for inst := range dirty {
+			state, vip, ok := apply(inst)
+			if !ok {
+				continue
 			}
+			if lastHooked[inst] == state {
+				continue
+			}
+			lastHooked[inst] = state
+			hook(inst, state, vip.String())
 		}
-		go hookScrptCall(cm)
-		return ci.State, nil
 	}
+}
 
-	tk.LogIt(tk.LogError, "[CLUSTER] Invalid State: %s\n", cm.State)
-	return ci.State, errors.New("invalid cluster-state")
-
+// ciRunKAHook - run the ka hook script, if there is one, for a state change
+func ciRunKAHook(inst, state, vip string) {
+	if _, err := os.Stat(cmn.KAHookScript); errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	command := cmn.KAHookScript + " " + inst + " " + state + " " + vip
+	cmd := exec.Command("bash", "-c", command)
+	output, err := cmd.Output()
+	if err != nil {
+		tk.LogIt(tk.LogError, "[CLUSTER] Error in applying ka hook : %s", err.Error())
+	} else {
+		tk.LogIt(tk.LogDebug, "[CLUSTER] ka hook output: %v\n", string(output))
+	}
 }
 
 // ClusterNodeAdd - routine to update cluster nodes
@@ -611,8 +734,7 @@ func (ch *CIStateH) CIBFDSessionAdd(bm cmn.BFDMod) (int, error) {
 		return -1, errors.New("bfd interval too low")
 	}
 
-	_, found := ch.ClusterMap[bm.Instance]
-	if !found {
+	if !ch.ciInstExists(bm.Instance) {
 		tk.LogIt(tk.LogError, "[CLUSTER] BFD SU - Cluster Instance %s not found\n", bm.Instance)
 		return -1, errors.New("cluster instance not found")
 	}
@@ -660,8 +782,7 @@ func (ch *CIStateH) CIBFDSessionDel(bm cmn.BFDMod) (int, error) {
 		return -1, errors.New("bfd session not running")
 	}
 
-	_, found := ch.ClusterMap[bm.Instance]
-	if !found {
+	if !ch.ciInstExists(bm.Instance) {
 		tk.LogIt(tk.LogError, "[CLUSTER] BFD SU - Cluster Instance %s not found\n", bm.Instance)
 		return -1, errors.New("cluster instance not found")
 	}

--- a/pkg/loxinet/loxinet.go
+++ b/pkg/loxinet/loxinet.go
@@ -353,6 +353,10 @@ func loxiNetInit() {
 			return
 		}
 
+		// Cluster state changes are applied to the root zone; start applying
+		// them now that it exists.
+		mh.has.CIStartSync()
+
 		if clusterMode {
 			if opts.Opts.Bgp {
 				tk.LogIt(tk.LogInfo, "init-wait cluster mode\n")

--- a/pkg/loxinet/rules.go
+++ b/pkg/loxinet/rules.go
@@ -388,6 +388,14 @@ type RuleH struct {
 	tlsCert    tls.Certificate
 	vipST      time.Time
 	vipAdvRep  vipAdvBurstSched
+
+	// cloudPrepared - whether the cloud VIP network is set up. Owned by the
+	// cluster sync worker, which is the only caller of the cloud prepare and
+	// unprepare hooks; nothing else reads or writes it.
+	cloudPrepared bool
+	// applyTestSeam - test hook, run between the first state read and the
+	// locked section of RulesApplyClusterState; nil outside tests
+	applyTestSeam func()
 }
 
 // RulesInit - initialize the Rules subsystem
@@ -3601,49 +3609,112 @@ func (R *RuleH) AdvRuleVIP(IP net.IP, eIP net.IP, inst string, egress bool, ctx 
 	return nil
 }
 
-// RulesSyncToClusterState - bring rules, VIPs and firewall entries in line
-// with a cluster state change
+// ciApplyMaxRestarts - how many times one RulesApplyClusterState pass may
+// start over because the state moved under it
+const ciApplyMaxRestarts = 3
+
+// RulesApplyClusterState - bring the firewall entries, VIPs and cloud network
+// of a cluster instance in line with its current state
 //
-// Always started with go from CIStateUpdate, one goroutine per transition,
-// and runs without mh.mtx. It must not be called synchronously while mh.mtx
-// is held: vipAdvBurstOnState takes that lock itself.
-func (R *RuleH) RulesSyncToClusterState(inst, ciStateStr string) {
+// Runs on the cluster sync worker only, never with mh.mtx held on entry. The
+// state applied is the one read under mh.mtx here, not the transition that
+// woke the worker: transitions that overlap collapse into their final value.
+// The rules and VIPs are applied under mh.mtx, the way the sweep applies
+// them, so nothing here races an API call. Only the cloud prepare and
+// unprepare hooks, which take seconds, run outside the lock.
+//
+// Returns the state and VIP applied. ok is false when the pass was abandoned
+// because the state kept moving: the change that forced that has already
+// queued the instance again, so the worker does not need to retry.
+func (R *RuleH) RulesApplyClusterState(inst string) (state string, vip net.IP, ok bool) {
+	cloud := mh.cloudHook != nil && inst == cmn.CIDefault
 
-	// For Cloud integrations, certain operations are performed only on default instance state changes
-	if mh.cloudHook != nil && inst == cmn.CIDefault {
-		if ciStateStr == cmn.CIMasterStateString {
-			mh.cloudHook.CloudPrepareVIPNetWork()
-		} else if ciStateStr == cmn.CIBackupStateString {
-			mh.cloudHook.CloudUnPrepareVIPNetWork()
+	for try := 0; ; try++ {
+		mh.mtx.Lock()
+		first, _ := mh.has.CIStateGetInst(inst)
+		mh.mtx.Unlock()
+
+		if R.applyTestSeam != nil {
+			R.applyTestSeam()
 		}
-	}
 
+		// The cloud network has to exist before a VIP can be bound to it,
+		// and it is prepared once per promotion: a failure is not retried
+		// until the next transition.
+		if cloud && first == cmn.CIMasterStateString && !R.cloudPrepared {
+			if err := mh.cloudHook.CloudPrepareVIPNetWork(); err != nil {
+				tk.LogIt(tk.LogError, "%s: vip network prepare failed: %v\n", mh.cloudLabel, err)
+			} else {
+				R.cloudPrepared = true
+			}
+		}
+
+		mh.mtx.Lock()
+		state, vip = mh.has.CIStateVipGetInst(inst)
+
+		// Promoted since the first read, with no cloud network to bind to:
+		// binding now would attach the VIPs to whatever interface is left
+		// from an earlier life. Start over so the prepare step sees MASTER.
+		if cloud && state == cmn.CIMasterStateString &&
+			first != cmn.CIMasterStateString && !R.cloudPrepared {
+			mh.mtx.Unlock()
+			if try < ciApplyMaxRestarts {
+				tk.LogIt(tk.LogInfo, "[CLUSTER] %s promoted during sync, restarting the pass\n", inst)
+				continue
+			}
+			tk.LogIt(tk.LogError, "[CLUSTER] %s state keeps moving, sync pass abandoned\n", inst)
+			return "", nil, false
+		}
+
+		R.rulesApplyStateLocked(inst, state)
+		mh.mtx.Unlock()
+
+		// A failed unprepare still counts as unprepared: the next promotion
+		// then rebuilds the network instead of binding to the remains.
+		if cloud && state == cmn.CIBackupStateString && R.cloudPrepared {
+			if err := mh.cloudHook.CloudUnPrepareVIPNetWork(); err != nil {
+				tk.LogIt(tk.LogError, "%s: vip network unprepare failed: %v\n", mh.cloudLabel, err)
+			}
+			R.cloudPrepared = false
+		}
+
+		return state, vip, true
+	}
+}
+
+// rulesApplyStateLocked - the part of RulesApplyClusterState that runs under
+// mh.mtx: firewall entries that follow the default instance, the VIP bind or
+// unbind of every VIP of the instance, and the advertisement burst
+func (R *RuleH) rulesApplyStateLocked(inst, state string) {
 	if inst == cmn.CIDefault {
 		for _, eFw := range R.tables[RtFw].eMap {
-			if eFw.act.action.(*ruleFwOpts).opt.onDflt {
-				if ciStateStr == cmn.CIMasterStateString || ciStateStr != cmn.CIBackupStateString {
-					eFw.Fw2DP(DpCreate)
-				} else if ciStateStr == cmn.CIBackupStateString {
-					eFw.Fw2DP(DpRemove)
-				}
+			if !eFw.act.action.(*ruleFwOpts).opt.onDflt {
+				continue
+			}
+			if state != cmn.CIBackupStateString {
+				eFw.Fw2DP(DpCreate)
+			} else {
+				eFw.Fw2DP(DpRemove)
 			}
 		}
 	}
 
-	for vip, vipElem := range R.vipMap {
+	// One main table dump for the whole pass, as in the sweep.
+	advCtx := new(vipAdvCtx)
+	for vipStr, vipElem := range R.vipMap {
 		if vipElem.inst != inst {
 			continue
 		}
 		ip := vipElem.pVIP
 		if ip == nil {
-			ip = net.ParseIP(vip)
+			ip = net.ParseIP(vipStr)
 		}
 		if ip != nil {
-			R.AdvRuleVIP(ip, net.ParseIP(vip), vipElem.inst, vipElem.egr, nil)
+			R.AdvRuleVIP(ip, net.ParseIP(vipStr), vipElem.inst, vipElem.egr, advCtx)
 		}
 	}
 
-	R.vipAdvBurstOnState(inst)
+	R.vipAdvBurstOnStateLocked(inst)
 }
 
 func (r *ruleEnt) RuleVIP2PrivIP() net.IP {

--- a/pkg/loxinet/utils_aws.go
+++ b/pkg/loxinet/utils_aws.go
@@ -177,7 +177,13 @@ func (aws *AWSAPIStruct) CloudPrepareVIPNetWork() error {
 		return nil
 	}
 
+	// This runs outside mh.mtx (the cluster sync worker keeps the AWS calls
+	// out of the lock), while the VIP path reads these globals under it from
+	// awsPrepDFLRoute and awsUpdatePrivateIP. So each write takes the lock
+	// for just the assignment.
+	mh.mtx.Lock()
 	setDFLRoute = true
+	mh.mtx.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*30))
 	defer cancel()
@@ -415,7 +421,9 @@ func (aws *AWSAPIStruct) CloudPrepareVIPNetWork() error {
 	}
 
 	loxiEniPrivIP := *intfOutput.NetworkInterface.PrivateIpAddress
+	mh.mtx.Lock()
 	loxiEniID = *intfOutput.NetworkInterface.NetworkInterfaceId
+	mh.mtx.Unlock()
 
 	tk.LogIt(tk.LogInfo, "Created interface (%s:%s) for loxilb instance %v\n", *intfOutput.NetworkInterface.NetworkInterfaceId, loxiEniPrivIP, vpcID)
 
@@ -495,7 +503,9 @@ retry:
 			goto retry
 		}
 	} else {
+		mh.mtx.Lock()
 		intfENIName = newIntfName
+		mh.mtx.Unlock()
 	}
 
 	return nil
@@ -615,6 +625,12 @@ func (aws *AWSAPIStruct) CloudDestroyVIPNetWork() error {
 }
 
 func (aws *AWSAPIStruct) CloudUnPrepareVIPNetWork() error {
+	// No AWS calls here, only netlink lookups and the loxilb route table,
+	// which the API changes under mh.mtx. The caller (the cluster sync
+	// worker) does not hold the lock.
+	mh.mtx.Lock()
+	defer mh.mtx.Unlock()
+
 	_, defaultDst, _ := net.ParseCIDR("0.0.0.0/0")
 	if intfENIName == "" {
 		tk.LogIt(tk.LogError, "failed to get ENI intf name (%s)\n", intfENIName)

--- a/pkg/loxinet/vipadv.go
+++ b/pkg/loxinet/vipadv.go
@@ -340,7 +340,8 @@ type vipAdvTarget struct {
 	iface string
 }
 
-// vipAdvBurstOnState - repeat the advertisement while the instance is master
+// vipAdvBurstOnStateLocked - repeat the advertisement while the instance is
+// master
 //
 // A promotion sends one gratuitous ARP or NA per VIP, and the next one is the
 // sweep's, up to VIPSweepDuration later. One frame is easy to lose - the link
@@ -351,22 +352,16 @@ type vipAdvTarget struct {
 // there is no stale entry to overwrite, the first ARP request resolves the
 // VIP on its own.
 //
-// The decision is taken on the state as it is now, not on the transition that
-// got us here. The cluster sync runs as one goroutine per transition with no
-// ordering between them, so a late BACKUP sync must not cancel the burst a
-// newer MASTER sync started. The read and the arm sit under one exclusive
-// lock: state changes happen under the same lock, so whichever sync runs
-// last acts on the true state at that moment. This nests s.mx inside mh.mtx;
-// nothing takes them the other way round - the burst goroutine takes mh.mtx
-// only from vipAdvBurstTargets, after run has been entered, and its cleanup
-// takes s.mx only after run has returned.
+// Must be called with mh.mtx held: the decision is taken on the state as it
+// is now, and state changes happen under the same lock, so the burst armed
+// here always matches the true state at that moment. This nests s.mx inside
+// mh.mtx; nothing takes them the other way round - the burst goroutine takes
+// mh.mtx only from vipAdvBurstTargets, after run has been entered, and its
+// cleanup takes s.mx only after run has returned.
 //
 // The repeats are advertisements only: the bind, cloud hook and neighbour
 // cleanup happened on the transition and are not redone.
-func (R *RuleH) vipAdvBurstOnState(inst string) {
-	mh.mtx.Lock()
-	defer mh.mtx.Unlock()
-
+func (R *RuleH) vipAdvBurstOnStateLocked(inst string) {
 	ciState, _ := mh.has.CIStateGetInst(inst)
 	repeat := opts.Opts.VIPAdvRepeat
 	if ciState != cmn.CIMasterStateString || repeat <= 0 {


### PR DESCRIPTION
## Problem

`CIStateUpdate` started one goroutine per cluster state transition (`go RulesSyncToClusterState(inst, state)`), and that goroutine walked `R.vipMap` and the firewall table **without `mh.mtx`** while rule add/delete writes both maps under it. When the Go runtime catches an iteration overlapping a write it aborts the process (`fatal error: concurrent map iteration and map write`). A failover that overlaps service churn (kube-loxilb, REST) is enough to hit it. Present since a3dec993 (2024-12).

Two more defects in the same path:

- The goroutine acted on the transition string it was handed, not on the current state, and nothing ordered the goroutines (since fc149ab2). A MASTER sync still inside `CloudPrepareVIPNetWork` (seconds of AWS calls) could finish after a flap-back BACKUP sync and leave `onDefault` firewall entries installed on a backup, or the cloud VIP network in an undefined state. `go hookScrptCall` (ka_hook.sh) had the same ordering problem.
- `AdvRuleVIP` edits the L3 interface tables (no lock of their own) and `CIStateGetInst` read `ClusterMap` with no lock from several paths (dpbroker, gobgpclient, VIP paths).

## Fix

- `CIStateUpdate` records the instance in a mailbox and wakes **one sync worker** (started after the root zone exists). The worker reads the live state and applies firewall entries, VIP bind/unbind and the advertisement burst **under `mh.mtx`**, the way the 30 s sweep already does; only the cloud prepare/unprepare hooks run outside the lock. Overlapping transitions collapse into their final value in decision order (same latest-wins semantics as #1132). ka_hook.sh runs from the worker, once per change of the applied state.
- A promotion that lands between the worker's first read and its locked section restarts the pass so the cloud network is prepared before any VIP is bound to it (bounded, then abandoned; the flip that forced it has already re-queued the instance).
- `ClusterMap` gets its own `RWMutex`, nested inside `mh.mtx`; the accessors take it, so the scattered lock-free reads are gone. `bgp.UpdateCIState` is called after the lock is released (it reads the state back).
- AWS hook: `CloudUnPrepareVIPNetWork` (no AWS calls, only netlink and the loxilb route table) runs under `mh.mtx`; the three globals `CloudPrepareVIPNetWork` writes are assigned under it. `awsPrepDFLRoute` is untouched (already under the lock via the VIP path).
- `vipAdvBurstOnState` becomes `vipAdvBurstOnStateLocked`.

## Behaviour changes

- Intermediate flaps are no longer applied one by one; the final state always is.
- The cloud network is prepared once per promotion (`CloudPrepareVIPNetWork` is destructive when re-run: it deletes and recreates the ENI, subnet and route table). A failed prepare is not retried until the next transition, as before.
- Each transition now holds `mh.mtx` for one sweep's worth of VIP work (per-VIP bind + GARP, plus the cloud private-IP call on AWS). REST calls queue behind it for that time. In the churn test below that is ~2 transitions/s with 20 VIPs and 1500 FW rules, no GARP timeouts. Splitting the bind (locked) from the GARP send (unlocked) the way `vipAdvBurstTargets` does is a possible follow-up.

## Verification

- `pkg/loxinet/cisync_test.go` (8 tests): worker latest-wins and ordering, hook dedupe, abandoned pass, `CIStateUpdate` no-op cases, `RulesApplyClusterState` restart-on-promotion, prepare-once/unprepare-once, non-default instance. `go test -race -count=10` clean.
- Race evidence on the `ensureLoxinet` harness (root): state flap + VIP add/delete concurrently. `origin/main`: 20 DATA RACE reports, all in the transition goroutine (`RulesSyncToClusterState` map walks, `AdvRuleVIP`/`logVipAdvIf`) vs `AddRuleVIP`/`DeleteRuleVIP`. This branch: 1 report, the pre-existing init race between `dpEbpfTicker` and `loxiNetInit`.
- Standalone churn case (one container, no peer; API flips MASTER<->BACKUP while FW/LB rules are added and deleted, 1500 FW + 20 LB preloaded, 60 s):

  | binary | result |
  |---|---|
  | main (`ghcr.io/loxilb-io/loxilb:latest`, built after #1132) | process died 3/3 runs (after 10 s, 7 s, 50 s): `fatal error: concurrent map iteration and map write` in `RulesSyncToClusterState`, created by `CIStateUpdate` |
  | this branch | alive 2/2 runs, ka_hook saw states in order |

- `cicd/ha1-vipadv` with this binary: all assertions OK.
- `cicd/sctpmh-seagull` with this binary on both nodes: cases 1-6 PASS. Case 7 (CT-less takeover) is flaky on main as well (0/3 on the image binary, 1/3 here, same signature: the two heartbeat-only paths do not always get a heartbeat inside the 30 s counter window; Linux hb_interval is 30 s). Per-run loxilb logs show one NOT_DEFINED->MASTER application per cold restart, VIP advertisement + burst, no pass restart, no abandoned pass, no panic. A harness fix for the case 7 window will come separately.

Follow-ups (separate PRs): widen the case 7 window; drop the llb2 re-restart recovery in `check_ha.sh` `restart_loxilbs_together` now that #1132 is in, and dump container logs on failure.
